### PR TITLE
Add examples to README for different style objects

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -45,6 +45,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "paulmolluzzo",
+      "name": "Paul Molluzzo",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/737065?v=3",
+      "profile": "https://paul.molluzzo.com",
+      "contributions": [
+        "doc",
+        "example"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -298,93 +298,89 @@ selectors, introduce keyframe animations, and use media queries:
 
 <details>
   <summary>pseudo-class</summary>
-  <p>
-    <pre>
-const MyLink = glamorous.a({
-  ':hover': {
-    color: 'red'
-  }
-})
-// Use in a render function
-`<MyLink href="https://github.com">`GitHub`</MyLink>`
-    </pre>
-  </p>
+  ```javascript
+    const MyLink = glamorous.a({
+      ':hover': {
+        color: 'red'
+      }
+    })
+    
+    // Use in a render function
+    <MyLink href="https://github.com">GitHub</MyLink>
+  ```
 </details>
 
 <details>
   <summary>pseudo-element</summary>
-  <p>
-    <pre>
-const MyListItem = glamorous.li({
-  listStyleType: 'none',
-  position: 'relative',
-  '&::before': {
-    content: `'#'`, // be sure the quotes are included in the passed string
-    display: 'block',
-    position: 'absolute',
-    left: '-20px',
-    width: '20px',
-    height: '20px'
-  }
-})
-// Use in a render function
-`<ul>`
-  `<MyListItem>`Item 1`</MyListItem>`
-  `<MyListItem>`Item 2`</MyListItem>`
-  `<MyListItem>`Item 3`</MyListItem>`
-`</ul>`
-    </pre>
-  </p>
+  ```javascript
+    const MyListItem = glamorous.li({
+      listStyleType: 'none',
+      position: 'relative',
+      '&::before': {
+        content: `'#'`, // be sure the quotes are included in the passed string
+        display: 'block',
+        position: 'absolute',
+        left: '-20px',
+        width: '20px',
+        height: '20px'
+      }
+    })
+    // Use in a render function
+    <ul>
+      <MyListItem>Item 1</MyListItem>
+      <MyListItem>Item 2</MyListItem>
+      <MyListItem>Item 3</MyListItem>
+    </ul>
+  ```
 </details>
 
 <details>
   <summary>Relational CSS Selectors</summary>
-  <p>
-    <pre>
-const MyDiv = glamorous.div({
-  display: 'block',
-  '& div': { color: 'red' }, // child selector
-  '& div:first-of-type': { textDecoration: 'underline' }, // psuedo-selector
-  '& > p': { color: 'blue' } // direct descendent
-})
-// Use in a render function
-`<MyDiv>`
-  `<div><p>Red Underlined Paragraph</p></div>`
-  `<div>Red Paragraph</div>`
-  `<p>Blue Paragraph</p>`
-`</MyDiv>`
-    </pre>
-  </p>
+  ```javascript
+    const MyDiv = glamorous.div({
+      display: 'block',
+      '& div': { color: 'red' }, // child selector
+      '& div:first-of-type': { textDecoration: 'underline' }, // psuedo-selector
+      '& > p': { color: 'blue' } // direct descendent
+    })
+
+    // Use in a render function
+    <MyDiv>
+      <div><p>Red Underlined Paragraph</p></div>
+      <div>Red Paragraph</div>
+      <p>Blue Paragraph</p>
+    </MyDiv>
+  ```
 </details>
 
 <details>
   <summary>Animations</summary>
-  <p>
-    <pre>
-// import css from glamor
-import { css } from 'glamor'
-// Define the animation styles
-const animationStyles = props => {
-  const bounce = css.keyframes({
-    '0%': { transform: `scale(1.01)` },
-    '100%': { transform: `scale(0.99)` }
-  })
-  return {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
-}
-// Define the element
-const AnimatedDiv = glamorous.div(animationStyles)
-// Use in a render function
-`<AnimatedDiv>`
-  Bounce.
-`</AnimatedDiv>`
-    </pre>
-  </p>
+  ```javascript
+    // import css from glamor
+    import { css } from 'glamor'
+
+    // Define the animation styles
+    const animationStyles = props => {
+      const bounce = css.keyframes({
+        '0%': { transform: `scale(1.01)` },
+        '100%': { transform: `scale(0.99)` }
+      })
+      return {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
+    }
+
+    // Define the element
+    const AnimatedDiv = glamorous.div(animationStyles)
+
+    // Use in a render function
+    <AnimatedDiv>
+      Bounce.
+    </AnimatedDiv>
+  ```
 </details>
 
 <details>
   <summary>Media Queries</summary>
-  <p>
-    <pre>
+  ```javascript
 const MyResponsiveDiv = glamorous.div({
   width: '100%',
   padding: 20,
@@ -397,8 +393,7 @@ const MyResponsiveDiv = glamorous.div({
 `<MyResponsiveDiv>`
   Responsive Content
 `</MyResponsiveDiv>`
-    </pre>
-  </p>
+  ```
 </details>
 
 ## Inspiration

--- a/README.md
+++ b/README.md
@@ -300,14 +300,14 @@ selectors, introduce keyframe animations, and use media queries:
   <summary>pseudo-class</summary>
 
   ```javascript
-    const MyLink = glamorous.a({
-      ':hover': {
-        color: 'red'
-      }
-    })
+const MyLink = glamorous.a({
+  ':hover': {
+    color: 'red'
+  }
+})
 
-    // Use in a render function
-    <MyLink href="https://github.com">GitHub</MyLink>
+// Use in a render function
+<MyLink href="https://github.com">GitHub</MyLink>
   ```
 </details>
 
@@ -315,24 +315,24 @@ selectors, introduce keyframe animations, and use media queries:
   <summary>pseudo-element</summary>
 
   ```javascript
-    const MyListItem = glamorous.li({
-      listStyleType: 'none',
-      position: 'relative',
-      '&::before': {
-        content: `'#'`, // be sure the quotes are included in the passed string
-        display: 'block',
-        position: 'absolute',
-        left: '-20px',
-        width: '20px',
-        height: '20px'
-      }
-    })
-    // Use in a render function
-    <ul>
-      <MyListItem>Item 1</MyListItem>
-      <MyListItem>Item 2</MyListItem>
-      <MyListItem>Item 3</MyListItem>
-    </ul>
+const MyListItem = glamorous.li({
+  listStyleType: 'none',
+  position: 'relative',
+  '&::before': {
+    content: `'#'`, // be sure the quotes are included in the passed string
+    display: 'block',
+    position: 'absolute',
+    left: '-20px',
+    width: '20px',
+    height: '20px'
+  }
+})
+// Use in a render function
+<ul>
+  <MyListItem>Item 1</MyListItem>
+  <MyListItem>Item 2</MyListItem>
+  <MyListItem>Item 3</MyListItem>
+</ul>
   ```
 </details>
 
@@ -340,19 +340,19 @@ selectors, introduce keyframe animations, and use media queries:
   <summary>Relational CSS Selectors</summary>
 
   ```javascript
-    const MyDiv = glamorous.div({
-      display: 'block',
-      '& div': { color: 'red' }, // child selector
-      '& div:first-of-type': { textDecoration: 'underline' }, // psuedo-selector
-      '& > p': { color: 'blue' } // direct descendent
-    })
+const MyDiv = glamorous.div({
+  display: 'block',
+  '& div': { color: 'red' }, // child selector
+  '& div:first-of-type': { textDecoration: 'underline' }, // psuedo-selector
+  '& > p': { color: 'blue' } // direct descendent
+})
 
-    // Use in a render function
-    <MyDiv>
-      <div><p>Red Underlined Paragraph</p></div>
-      <div>Red Paragraph</div>
-      <p>Blue Paragraph</p>
-    </MyDiv>
+// Use in a render function
+<MyDiv>
+  <div><p>Red Underlined Paragraph</p></div>
+  <div>Red Paragraph</div>
+  <p>Blue Paragraph</p>
+</MyDiv>
   ```
 </details>
 
@@ -360,25 +360,25 @@ selectors, introduce keyframe animations, and use media queries:
   <summary>Animations</summary>
 
   ```javascript
-    // import css from glamor
-    import { css } from 'glamor'
+// import css from glamor
+import { css } from 'glamor'
 
-    // Define the animation styles
-    const animationStyles = props => {
-      const bounce = css.keyframes({
-        '0%': { transform: `scale(1.01)` },
-        '100%': { transform: `scale(0.99)` }
-      })
-      return {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
-    }
+// Define the animation styles
+const animationStyles = props => {
+  const bounce = css.keyframes({
+    '0%': { transform: `scale(1.01)` },
+    '100%': { transform: `scale(0.99)` }
+  })
+  return {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
+}
 
-    // Define the element
-    const AnimatedDiv = glamorous.div(animationStyles)
+// Define the element
+const AnimatedDiv = glamorous.div(animationStyles)
 
-    // Use in a render function
-    <AnimatedDiv>
-      Bounce.
-    </AnimatedDiv>
+// Use in a render function
+<AnimatedDiv>
+  Bounce.
+</AnimatedDiv>
   ```
 </details>
 
@@ -386,18 +386,18 @@ selectors, introduce keyframe animations, and use media queries:
   <summary>Media Queries</summary>
 
   ```javascript
-    const MyResponsiveDiv = glamorous.div({
-      width: '100%',
-      padding: 20,
-      '@media(min-width: 400px)': {
-        width: '85%',
-        padding: 0
-      }
-    })
-    // Use in a render function
-    <MyResponsiveDiv>
-      Responsive Content
-    </MyResponsiveDiv>
+const MyResponsiveDiv = glamorous.div({
+  width: '100%',
+  padding: 20,
+  '@media(min-width: 400px)': {
+    width: '85%',
+    padding: 0
+  }
+})
+// Use in a render function
+<MyResponsiveDiv>
+  Responsive Content
+</MyResponsiveDiv>
   ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ selectors, introduce keyframe animations, and use media queries:
         color: 'red'
       }
     })
-    
+
     // Use in a render function
     <MyLink href="https://github.com">GitHub</MyLink>
   ```
@@ -381,18 +381,18 @@ selectors, introduce keyframe animations, and use media queries:
 <details>
   <summary>Media Queries</summary>
   ```javascript
-const MyResponsiveDiv = glamorous.div({
-  width: '100%',
-  padding: 20,
-  '@media(min-width: 400px)': {
-    width: '85%',
-    padding: 0
-  }
-})
-// Use in a render function
-`<MyResponsiveDiv>`
-  Responsive Content
-`</MyResponsiveDiv>`
+    const MyResponsiveDiv = glamorous.div({
+      width: '100%',
+      padding: 20,
+      '@media(min-width: 400px)': {
+        width: '85%',
+        padding: 0
+      }
+    })
+    // Use in a render function
+    <MyResponsiveDiv>
+      Responsive Content
+    </MyResponsiveDiv>
   ```
 </details>
 

--- a/README.md
+++ b/README.md
@@ -235,14 +235,16 @@ const MyDiv = glamorous.div({
 ##### Animations
 
 ```js
+// import css from glamor
+import { css } from 'glamor'
+
 // Define the animation styles
 const animationStyles = props => {
   const bounce = css.keyframes({
     '0%': { transform: `scale(1.01)` },
     '100%': { transform: `scale(0.99)` }
   })
-  const animationStyles = {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
-  return animationStyles
+  return {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
 }
 
 // Define the element

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ selectors, introduce keyframe animations, and use media queries:
 <details>
   <summary>pseudo-class</summary>
 
-  ```javascript
+```javascript
 const MyLink = glamorous.a({
   ':hover': {
     color: 'red'
@@ -308,13 +308,13 @@ const MyLink = glamorous.a({
 
 // Use in a render function
 <MyLink href="https://github.com">GitHub</MyLink>
-  ```
+```
 </details>
 
 <details>
   <summary>pseudo-element</summary>
 
-  ```javascript
+```javascript
 const MyListItem = glamorous.li({
   listStyleType: 'none',
   position: 'relative',
@@ -333,13 +333,13 @@ const MyListItem = glamorous.li({
   <MyListItem>Item 2</MyListItem>
   <MyListItem>Item 3</MyListItem>
 </ul>
-  ```
+```
 </details>
 
 <details>
   <summary>Relational CSS Selectors</summary>
 
-  ```javascript
+```javascript
 const MyDiv = glamorous.div({
   display: 'block',
   '& div': { color: 'red' }, // child selector
@@ -353,13 +353,13 @@ const MyDiv = glamorous.div({
   <div>Red Paragraph</div>
   <p>Blue Paragraph</p>
 </MyDiv>
-  ```
+```
 </details>
 
 <details>
   <summary>Animations</summary>
 
-  ```javascript
+```javascript
 // import css from glamor
 import { css } from 'glamor'
 
@@ -379,13 +379,13 @@ const AnimatedDiv = glamorous.div(animationStyles)
 <AnimatedDiv>
   Bounce.
 </AnimatedDiv>
-  ```
+```
 </details>
 
 <details>
   <summary>Media Queries</summary>
 
-  ```javascript
+```javascript
 const MyResponsiveDiv = glamorous.div({
   width: '100%',
   padding: 20,
@@ -398,7 +398,7 @@ const MyResponsiveDiv = glamorous.div({
 <MyResponsiveDiv>
   Responsive Content
 </MyResponsiveDiv>
-  ```
+```
 </details>
 
 ## Inspiration

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ small footprint (<5kb gzipped), and great performance (via [`glamor`][glamor]).
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Chat][chat-badge]][chat]
 [![Donate][donate-badge]][donate]
@@ -438,8 +438,8 @@ If you need help, please fork [this codepen][help-pen] and bring it up in
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/paypal/glamorous/commits?author=kentcdodds) [📖](https://github.com/paypal/glamorous/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/paypal/glamorous/commits?author=kentcdodds) | [<img src="https://avatars0.githubusercontent.com/u/587016?v=3" width="100px;"/><br /><sub>Ives van Hoorne</sub>](http://ivesvh.com)<br />💡 | [<img src="https://avatars3.githubusercontent.com/u/4614574?v=3" width="100px;"/><br /><sub>Gerardo Nardelli</sub>](https://gnardelli.com)<br />[📖](https://github.com/paypal/glamorous/commits?author=patitonar) | [<img src="https://avatars0.githubusercontent.com/u/14236753?v=3" width="100px;"/><br /><sub>Chandan Rai</sub>](https://github.com/crowchirp)<br />[📖](https://github.com/paypal/glamorous/commits?author=crowchirp) |
-| :---: | :---: | :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/paypal/glamorous/commits?author=kentcdodds) [📖](https://github.com/paypal/glamorous/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/paypal/glamorous/commits?author=kentcdodds) | [<img src="https://avatars0.githubusercontent.com/u/587016?v=3" width="100px;"/><br /><sub>Ives van Hoorne</sub>](http://ivesvh.com)<br />💡 | [<img src="https://avatars3.githubusercontent.com/u/4614574?v=3" width="100px;"/><br /><sub>Gerardo Nardelli</sub>](https://gnardelli.com)<br />[📖](https://github.com/paypal/glamorous/commits?author=patitonar) | [<img src="https://avatars0.githubusercontent.com/u/14236753?v=3" width="100px;"/><br /><sub>Chandan Rai</sub>](https://github.com/crowchirp)<br />[📖](https://github.com/paypal/glamorous/commits?author=crowchirp) | [<img src="https://avatars2.githubusercontent.com/u/737065?v=3" width="100px;"/><br /><sub>Paul Molluzzo</sub>](https://paul.molluzzo.com)<br />[📖](https://github.com/paypal/glamorous/commits?author=paulmolluzzo) 💡 |
+| :---: | :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ selectors, introduce keyframe animations, and use media queries:
 
 <details>
   <summary>pseudo-class</summary>
+
   ```javascript
     const MyLink = glamorous.a({
       ':hover': {
@@ -312,6 +313,7 @@ selectors, introduce keyframe animations, and use media queries:
 
 <details>
   <summary>pseudo-element</summary>
+
   ```javascript
     const MyListItem = glamorous.li({
       listStyleType: 'none',
@@ -336,6 +338,7 @@ selectors, introduce keyframe animations, and use media queries:
 
 <details>
   <summary>Relational CSS Selectors</summary>
+
   ```javascript
     const MyDiv = glamorous.div({
       display: 'block',
@@ -355,6 +358,7 @@ selectors, introduce keyframe animations, and use media queries:
 
 <details>
   <summary>Animations</summary>
+
   ```javascript
     // import css from glamor
     import { css } from 'glamor'
@@ -380,6 +384,7 @@ selectors, introduce keyframe animations, and use media queries:
 
 <details>
   <summary>Media Queries</summary>
+
   ```javascript
     const MyResponsiveDiv = glamorous.div({
       width: '100%',

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ These can be style objects or functions which are invoked with `props` on every
 render and return style objects. To learn more about what these style objects
 can look like, please take a look at the [`glamor`][glamor] documentation.
 
-Style objects can affect pseudo-classes and pseduo-elements, children (and other CSS selectors),
-introduce keyframe animations, and use media queries:
+Style objects can affect pseudo-classes and pseduo-elements, complex CSS
+selectors, introduce keyframe animations, and use media queries:
 
 ##### pseudo-class
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ const animationStyles = props => {
 }
 
 // Define the element
-const AnimatedDiv = glamorous.div(crazyStyles)
+const AnimatedDiv = glamorous.div(animationStyles)
 
 // Use in a render function
 <AnimatedDiv>

--- a/README.md
+++ b/README.md
@@ -167,113 +167,12 @@ wrapping a component you intend to style, you'll need to make sure you accept
 the `className` as a prop and apply it to where you want the styles applied in
 your custom component (normally the root element).
 
-#### ...styles
+##### ...styles
 
 The `glamorousComponentFactory` accepts any number of style object arguments.
 These can be style objects or functions which are invoked with `props` on every
 render and return style objects. To learn more about what these style objects
 can look like, please take a look at the [`glamor`][glamor] documentation.
-
-Style objects can affect pseudo-classes and pseduo-elements, complex CSS
-selectors, introduce keyframe animations, and use media queries:
-
-##### pseudo-class
-
-```js
-const MyLink = glamorous.a({
-  ':hover': {
-    color: 'red'
-  }
-})
-
-// Use in a render function
-<MyLink href="https://github.com">GitHub</MyLink>
-```
-
-##### pseudo-element
-
-```js
-const MyListItem = glamorous.li({
-  listStyleType: 'none',
-  position: 'relative',
-  '&::before': {
-    content: `'#'`, // be sure the quotes are included in the passed string
-    display: 'block',
-    position: 'absolute',
-    left: '-20px',
-    width: '20px',
-    height: '20px'
-  }
-})
-
-// Use in a render function
-<ul>
-  <MyListItem>Item 1</MyListItem>
-  <MyListItem>Item 2</MyListItem>
-  <MyListItem>Item 3</MyListItem>
-</ul>
-```
-
-##### Relational CSS Selectors
-
-```js
-const MyDiv = glamorous.div({
-  display: 'block',
-  '& div': { color: 'red' }, // child selector
-  '& div:first-of-type': { textDecoration: 'underline' }, // psuedo-selector
-  '& > p': { color: 'blue' } // direct descendent
-})
-
-// Use in a render function
-<MyDiv>
-  <div><p>Red Underlined Paragraph</p></div>
-  <div>Red Paragraph</div>
-  <p>Blue Paragraph</p>
-</MyDiv>
-```
-
-##### Animations
-
-```js
-// import css from glamor
-import { css } from 'glamor'
-
-// Define the animation styles
-const animationStyles = props => {
-  const bounce = css.keyframes({
-    '0%': { transform: `scale(1.01)` },
-    '100%': { transform: `scale(0.99)` }
-  })
-  return {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
-}
-
-// Define the element
-const AnimatedDiv = glamorous.div(animationStyles)
-
-// Use in a render function
-<AnimatedDiv>
-  Bounce.
-</AnimatedDiv>
-```
-
-##### Media Queries
-
-```js
-const MyResponsiveDiv = glamorous.div({
-  width: '100%',
-  padding: 20,
-  '@media(min-width: 400px)': {
-    width: '85%',
-    padding: 0
-  }
-})
-
-// Use in a render function
-<MyResponsiveDiv>
-  Responsive Content
-</MyResponsiveDiv>
-
-```
 
 #### GlamorousComponent
 
@@ -391,6 +290,116 @@ Because both `glamor` and `react` support SSR, `glamorous` does too! I actually
 do this on [my personal site](https://github.com/kentcdodds/kentcdodds.com)
 which is generated at build-time on the server. Learn about rendering
 [`react` on the server][react-ssr] and [`glamor` too][glamor-ssr].
+
+### Example Style Objects
+
+Style objects can affect pseudo-classes and pseduo-elements, complex CSS
+selectors, introduce keyframe animations, and use media queries:
+
+<details>
+  <summary>pseudo-class</summary>
+  <p>
+    <pre>
+const MyLink = glamorous.a({
+  ':hover': {
+    color: 'red'
+  }
+})
+// Use in a render function
+`<MyLink href="https://github.com">GitHub</MyLink>`
+    </pre>
+  </p>
+</details>
+
+<details>
+  <summary>pseudo-element</summary>
+  <p>
+    <pre>
+const MyListItem = glamorous.li({
+  listStyleType: 'none',
+  position: 'relative',
+  '&::before': {
+    content: `'#'`, // be sure the quotes are included in the passed string
+    display: 'block',
+    position: 'absolute',
+    left: '-20px',
+    width: '20px',
+    height: '20px'
+  }
+})
+// Use in a render function
+`<ul>`
+  `<MyListItem>Item 1</MyListItem>`
+  `<MyListItem>Item 2</MyListItem>`
+  `<MyListItem>Item 3</MyListItem>`
+`</ul>`
+    </pre>
+  </p>
+</details>
+
+<details>
+  <summary>Relational CSS Selectors</summary>
+  <p>
+    <pre>
+const MyDiv = glamorous.div({
+  display: 'block',
+  '& div': { color: 'red' }, // child selector
+  '& div:first-of-type': { textDecoration: 'underline' }, // psuedo-selector
+  '& > p': { color: 'blue' } // direct descendent
+})
+// Use in a render function
+`<MyDiv>`
+  `<div><p>Red Underlined Paragraph</p></div>`
+  `<div>Red Paragraph</div>`
+  `<p>Blue Paragraph</p>`
+`</MyDiv>`
+    </pre>
+  </p>
+</details>
+
+<details>
+  <summary>Animations</summary>
+  <p>
+    <pre>
+// import css from glamor
+import { css } from 'glamor'
+// Define the animation styles
+const animationStyles = props => {
+  const bounce = css.keyframes({
+    '0%': { transform: `scale(1.01)` },
+    '100%': { transform: `scale(0.99)` }
+  })
+  return {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
+}
+// Define the element
+const AnimatedDiv = glamorous.div(animationStyles)
+// Use in a render function
+`<AnimatedDiv>`
+  Bounce.
+`</AnimatedDiv>`
+    </pre>
+  </p>
+</details>
+
+<details>
+  <summary>Media Queries</summary>
+  <p>
+    <pre>
+const MyResponsiveDiv = glamorous.div({
+  width: '100%',
+  padding: 20,
+  '@media(min-width: 400px)': {
+    width: '85%',
+    padding: 0
+  }
+})
+// Use in a render function
+`<MyResponsiveDiv>`
+  Responsive Content
+`</MyResponsiveDiv>`
+    </pre>
+  </p>
+</details>
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ const MyLink = glamorous.a({
   }
 })
 // Use in a render function
-`<MyLink href="https://github.com">GitHub</MyLink>`
+`<MyLink href="https://github.com">`GitHub`</MyLink>`
     </pre>
   </p>
 </details>
@@ -329,9 +329,9 @@ const MyListItem = glamorous.li({
 })
 // Use in a render function
 `<ul>`
-  `<MyListItem>Item 1</MyListItem>`
-  `<MyListItem>Item 2</MyListItem>`
-  `<MyListItem>Item 3</MyListItem>`
+  `<MyListItem>`Item 1`</MyListItem>`
+  `<MyListItem>`Item 2`</MyListItem>`
+  `<MyListItem>`Item 3`</MyListItem>`
 `</ul>`
     </pre>
   </p>

--- a/README.md
+++ b/README.md
@@ -167,12 +167,111 @@ wrapping a component you intend to style, you'll need to make sure you accept
 the `className` as a prop and apply it to where you want the styles applied in
 your custom component (normally the root element).
 
-##### ...styles
+#### ...styles
 
 The `glamorousComponentFactory` accepts any number of style object arguments.
 These can be style objects or functions which are invoked with `props` on every
 render and return style objects. To learn more about what these style objects
 can look like, please take a look at the [`glamor`][glamor] documentation.
+
+Style objects can affect pseudo-classes and pseduo-elements, children (and other CSS selectors),
+introduce keyframe animations, and use media queries:
+
+##### pseudo-class
+
+```js
+const MyLink = glamorous.a({
+  ':hover': {
+    color: 'red'
+  }
+})
+
+// Use in a render function
+<MyLink href="https://github.com">GitHub</MyLink>
+```
+
+##### pseudo-element
+
+```js
+const MyListItem = glamorous.li({
+  listStyleType: 'none',
+  position: 'relative',
+  '&::before': {
+    content: `'#'`, // be sure the quotes are included in the passed string
+    display: 'block',
+    position: 'absolute',
+    left: '-20px',
+    width: '20px',
+    height: '20px'
+  }
+})
+
+// Use in a render function
+<ul>
+  <MyListItem>Item 1</MyListItem>
+  <MyListItem>Item 2</MyListItem>
+  <MyListItem>Item 3</MyListItem>
+</ul>
+```
+
+##### Relational CSS Selectors
+
+```js
+const MyDiv = glamorous.div({
+  display: 'block',
+  '& div': { color: 'red' }, // child selector
+  '& div:first-of-type': { textDecoration: 'underline' }, // psuedo-selector
+  '& > p': { color: 'blue' } // direct descendent
+})
+
+// Use in a render function
+<MyDiv>
+  <div><p>Red Underlined Paragraph</p></div>
+  <div>Red Paragraph</div>
+  <p>Blue Paragraph</p>
+</MyDiv>
+```
+
+##### Animations
+
+```js
+// Define the animation styles
+const animationStyles = props => {
+  const bounce = css.keyframes({
+    '0%': { transform: `scale(1.01)` },
+    '100%': { transform: `scale(0.99)` }
+  })
+  const animationStyles = {animation: `${bounce} 0.2s infinite ease-in-out alternate`}
+  return animationStyles
+}
+
+// Define the element
+const AnimatedDiv = glamorous.div(crazyStyles)
+
+// Use in a render function
+<AnimatedDiv>
+  Bounce.
+</AnimatedDiv>
+```
+
+##### Media Queries
+
+```js
+const MyResponsiveDiv = glamorous.div({
+  width: '100%',
+  padding: 20,
+  '@media(min-width: 400px)': {
+    width: '85%',
+    padding: 0
+  }
+})
+
+// Use in a render function
+<MyResponsiveDiv>
+  Responsive Content
+</MyResponsiveDiv>
+
+```
 
 #### GlamorousComponent
 


### PR DESCRIPTION
This helps with #10.

**What**:
Added some style examples to the README. Some were taken from [this Medium post](https://medium.com/@kentcdodds/introducing-glamorous-fb3c9f4ed20e), others I just whipped up.

**Why**:
The examples in the article were helpful for knowing possibilities and syntax. Might as well make it easier to find.

**How**:
Added to the README.