### PR TITLE
WIP: feat(core): Add jsx style components to glamorous export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,9 @@
  */
 import React from 'react'
 import {css, styleSheet} from 'glamor'
-import * as jsxStyleComponents from 'glamor/jsxstyle'
 import shouldForwardProperty from './should-forward-property'
 import domElements from './dom-elements'
-import jsxStyleComponentTags from './jsxstyle-components'
+import jsxStyleComponents from './jsxstyle-components'
 
 const {PropTypes} = React
 
@@ -130,23 +129,18 @@ Object.assign(
 /*
  * This creates a glamorousComponentFactory for every jsxstyle element so you
  * can simply do:
- * const GreenBlock = glamorous.block({
+ * const GreenBlock = glamorous.display.block({
  *   backgroundColor: 'green',
  *   padding: 20,
  * })
  * <GreenBlock>Click Me!</GreenBlock>
  */
-Object.assign(
-  glamorous,
-  jsxStyleComponentTags.reduce(
-    (getters, tag) => {
-      const capitalTag = capitalize(tag)
-      const jsxStyleComponent = jsxStyleComponents[capitalTag]
-      getters[tag] = glamorous(jsxStyleComponent)
-      return getters
-    },
-    {},
-  ),
+glamorous.display = jsxStyleComponents.reduce(
+  (getters, {name, tag, styles}) => {
+    getters[name] = glamorous[tag](styles)
+    return getters
+  },
+  {},
 )
 
 /*
@@ -176,18 +170,18 @@ Object.assign(
 /*
  * This creates glamorous components matching components produced by jsxstyle
  * simply do:
- * <glamorous.Block>
+ * <glamorous.display.Block>
  *   I'm a block!
- * </glamorous.Block>
+ * </glamorous.display.Block>
  */
 Object.assign(
-  glamorous,
-  jsxStyleComponentTags.reduce(
-    (comps, tag) => {
-      const capitalTag = capitalize(tag)
-      comps[capitalTag] = glamorous[tag]()
-      comps[capitalTag].displayName = `glamorous.${capitalTag}`
-      comps[capitalTag].propsAreCssOverrides = true
+  glamorous.display,
+  jsxStyleComponents.reduce(
+    (comps, {name, tag, styles}) => {
+      const capitalName = capitalize(name)
+      comps[capitalName] = glamorous[tag](styles)
+      comps[capitalName].displayName = `glamorous.${capitalName}`
+      comps[capitalName].propsAreCssOverrides = true
       return comps
     },
     {},

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,10 @@
  */
 import React from 'react'
 import {css, styleSheet} from 'glamor'
+import * as jsxStyleComponents from 'glamor/jsxstyle'
 import shouldForwardProperty from './should-forward-property'
 import domElements from './dom-elements'
+import jsxStyleComponentTags from './jsxstyle-components'
 
 const {PropTypes} = React
 
@@ -126,6 +128,28 @@ Object.assign(
 )
 
 /*
+ * This creates a glamorousComponentFactory for every jsxstyle element so you
+ * can simply do:
+ * const GreenBlock = glamorous.block({
+ *   backgroundColor: 'green',
+ *   padding: 20,
+ * })
+ * <GreenBlock>Click Me!</GreenBlock>
+ */
+Object.assign(
+  glamorous,
+  jsxStyleComponentTags.reduce(
+    (getters, tag) => {
+      const capitalTag = capitalize(tag)
+      const jsxStyleComponent = jsxStyleComponents[capitalTag]
+      getters[tag] = glamorous(jsxStyleComponent)
+      return getters
+    },
+    {},
+  ),
+)
+
+/*
  * This creates a glamorous component for each DOM element so you can
  * simply do:
  * <glamorous.Div
@@ -138,6 +162,27 @@ Object.assign(
 Object.assign(
   glamorous,
   domElements.reduce(
+    (comps, tag) => {
+      const capitalTag = capitalize(tag)
+      comps[capitalTag] = glamorous[tag]()
+      comps[capitalTag].displayName = `glamorous.${capitalTag}`
+      comps[capitalTag].propsAreCssOverrides = true
+      return comps
+    },
+    {},
+  ),
+)
+
+/*
+ * This creates glamorous components matching components produced by jsxstyle
+ * simply do:
+ * <glamorous.Block>
+ *   I'm a block!
+ * </glamorous.Block>
+ */
+Object.assign(
+  glamorous,
+  jsxStyleComponentTags.reduce(
     (comps, tag) => {
       const capitalTag = capitalize(tag)
       comps[capitalTag] = glamorous[tag]()

--- a/src/jsxstyle-components.js
+++ b/src/jsxstyle-components.js
@@ -1,0 +1,9 @@
+// Mostly copied from:
+// https://github.com/threepointone/glamor/blob/
+// 5e7d988211330b8e2fca5bb8da78e35051444efd/src/jsxstyle.js
+/*
+ * This is used to generate the helper functions
+ * like: glamorous.block and the <glamorous.Block /> elements
+ */
+
+export default ['view', 'block', 'inlineBlock', 'flex', 'row', 'column']

--- a/src/jsxstyle-components.js
+++ b/src/jsxstyle-components.js
@@ -6,4 +6,47 @@
  * like: glamorous.block and the <glamorous.Block /> elements
  */
 
-export default ['view', 'block', 'inlineBlock', 'flex', 'row', 'column']
+export default [
+  {
+    name: 'view',
+    tag: 'div',
+    styles: {},
+  },
+  {
+    name: 'block',
+    tag: 'div',
+    styles: {
+      display: 'block',
+    },
+  },
+  {
+    name: 'inlineBlock',
+    tag: 'div',
+    styles: {
+      display: 'inline-block',
+    },
+  },
+  {
+    name: 'flex',
+    tag: 'div',
+    styles: {
+      display: 'flex',
+    },
+  },
+  {
+    name: 'row',
+    tag: 'div',
+    styles: {
+      display: 'flex',
+      flexDirection: 'row',
+    },
+  },
+  {
+    name: 'column',
+    tag: 'div',
+    styles: {
+      display: 'flex',
+      flexDirection: 'column',
+    },
+  },
+]


### PR DESCRIPTION
This uses the components exported from `glamor/jsxstyle` and assigns them to the `glamorous` object
already exported as additional components.

**What**:
This is an attempt to fix #20 by including the jsxstyle components that `glamor` exports.

**Why**:
Suggested by @kentcdodds to ease developers into using the `glamorous` API.

**How**:
I'm importing the `glamor/jsxstyle` and using an array of their component names to extend  `glamorous` with these components, nearly identically to the way `glamorous` adds support for components like `glamorous.Div`

Currently this is not really working for me, and I'm not sure if I'm approaching this entirely incorrectly or what. If I "manually" modify `glamorous` in a project to do exactly the same things that I'm doing in this commit it works, but it seems to fail. I might be overlooking something, so if @kentcdodds or anyone has advice please feel free to comment.

I'm testing by importing this updated build into the [`with-glamorous` example for Next](https://github.com/zeit/next.js/tree/master/examples/with-glamorous).

The error I get now is:

```
Cannot read property 'comp' of undefined
TypeError: Cannot read property 'comp' of undefined
    at getGlamorousComponentMetadata (/Users/paul/open-source/glamorous/dist/glamorous.cjs.js:6233:28)
    at Function.glamorousComponentFactory [as view] (/Users/paul/open-source/glamorous/dist/glamorous.cjs.js:6222:39)
    at /Users/paul/open-source/glamorous/dist/glamorous.cjs.js:6310:37
    at Array.reduce (native)
    at Object.<anonymous> (/Users/paul/open-source/glamorous/dist/glamorous.cjs.js:6308:48)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```

If there's any feedback or direction to help get this done I'd be super grateful! 🙏 