### PR TITLE
chore(config): Add union merge strategy for README.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
 *.js text eol=lf
+README.md merge=union


### PR DESCRIPTION
**What**:
With this inclusion git will attempt to keep multiple changes to a README to avoid conflicts

**Why**:
This is something I learned about [here](https://github.com/sindresorhus/refined-github/pull/23). That project had lots of changes to the README, and in `glamorous` the `all-contributors` might cause unnecessary conflicts. This could be nice to have and avoid merging/rebasing a PR.

**How**:
Small change in the `.gitattributes` file.

More info is available here: https://github.com/isaacs/github/issues/487
