### PR TITLE
fix(umd): add json plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-json": "^2.1.0",
     "rollup-plugin-node-resolve": "^3.0.0",
     "rollup-plugin-uglify": "^1.0.1",
     "semantic-release": "^6.3.6",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,7 @@
 import rollupBabel from 'rollup-plugin-babel'
 import commonjs from 'rollup-plugin-commonjs'
 import nodeResolve from 'rollup-plugin-node-resolve'
+import json from 'rollup-plugin-json'
 import uglify from 'rollup-plugin-uglify'
 
 const minify = process.env.MINIFY
@@ -25,6 +26,7 @@ export default {
   plugins: [
     nodeResolve({jsnext: true, main: true}),
     commonjs({include: 'node_modules/**'}),
+    json(),
     rollupBabel({
       exclude: 'node_modules/**',
       babelrc: false,

--- a/src/dom-elements.js
+++ b/src/dom-elements.js
@@ -1,0 +1,8 @@
+import htmlTagNames from 'html-tag-names'
+import svgTagNames from 'svg-tag-names'
+
+const domElements = htmlTagNames
+  .concat(svgTagNames)
+  .filter((tag, index, array) => array.indexOf(tag) === index)
+
+export default domElements

--- a/src/index.js
+++ b/src/index.js
@@ -5,13 +5,7 @@
 import React from 'react'
 import {css, styleSheet} from 'glamor'
 import shouldForwardProperty from './should-forward-property'
-
-const htmlTagNames = require('html-tag-names')
-const svgTagNames = require('svg-tag-names')
-
-const domElements = htmlTagNames
-  .concat(svgTagNames)
-  .filter((tag, index, array) => array.indexOf(tag) === index)
+import domElements from './dom-elements'
 
 const {PropTypes} = React
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5285,6 +5285,12 @@ rollup-plugin-commonjs@^8.0.2:
     resolve "^1.1.7"
     rollup-pluginutils "^2.0.1"
 
+rollup-plugin-json@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-json/-/rollup-plugin-json-2.1.0.tgz#7f8e1b2b156932dd934b938dc5547e4118d4121f"
+  dependencies:
+    rollup-pluginutils "^1.5.2"
+
 rollup-plugin-node-resolve@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
@@ -5300,7 +5306,7 @@ rollup-plugin-uglify@^1.0.1:
   dependencies:
     uglify-js "^2.6.1"
 
-rollup-pluginutils@^1.5.0:
+rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This adds `rollup-plugin-json`

<!-- Why are these changes necessary? -->
**Why**: Because we broke the rollup build when we started requiring packages that use `main` as a `json` file 😄 

<!-- How were these changes implemented? -->
**How**: add the plugin, also refactor things a little bit to be cleaner.

cc: @tsriram