### PR TITLE
test(dist): add dist-test

### DIFF
--- a/dist-test/index.js
+++ b/dist-test/index.js
@@ -1,0 +1,76 @@
+/*
+ * This file is here to validate that the built version
+ * of the library exposes the module in the way that we
+ * want it to. Specifically that the ES6 module import can
+ * get the glamorous function via default import. Also that
+ * the CommonJS require returns the glamorous function
+ * (rather than an object that has the glamorous as a
+ * `default` property).
+ *
+ * This file is unable to validate the global export.
+ */
+import assert from 'assert'
+import {oneLine} from 'common-tags'
+
+import esImport from '../dist/glamorous.es'
+import cjsImport from '../dist/glamorous.cjs'
+import umdImport from '../dist/glamorous.umd'
+
+// intentionally left out because you shouldn't ever
+// try to require the ES file in CommonJS
+// const esRequire = require('../dist/glamorous.es')
+const cjsRequire = require('../dist/glamorous.cjs')
+const umdRequire = require('../dist/glamorous.umd')
+
+assert(isGlamorousFunction(esImport), 'ES build has a problem with ES Modules')
+
+// intentionally left out ☝️
+// assert(isGlamorousFunction(esRequire), 'ES build has a problem with CJS')
+
+assert(
+  isGlamorousFunction(cjsImport),
+  'CJS build has a problem with ES Modules',
+)
+
+assert(isGlamorousFunction(cjsRequire), 'CJS build has a problem with CJS')
+
+assert(
+  isGlamorousFunction(umdImport),
+  'UMD build has a problem with ES Modules',
+)
+
+assert(isGlamorousFunction(umdRequire), 'UMD build has a problem with CJS')
+
+// TODO: how could we validate the global export?
+
+console.log('Built modules look good 👍')
+
+function isGlamorousFunction(thing) {
+  if (typeof thing !== 'function') {
+    console.error(
+      oneLine`
+        glamorous thing should be a function.
+        It's a ${typeof thing} with the
+        properties of: ${Object.keys(thing).join(', ')}
+      `,
+    )
+    return false
+  }
+  if (thing.name !== 'glamorous') {
+    console.error(
+      oneLine`
+        the function is not called "glamorous".
+        It's called ${thing.name}
+      `,
+    )
+    return false
+  }
+  return true
+}
+
+/*
+ eslint
+  no-console: 0,
+  import/extensions: 0,
+  import/no-unresolved: 0
+ */

--- a/package-scripts.js
+++ b/package-scripts.js
@@ -23,6 +23,10 @@ module.exports = {
     test: {
       default: 'jest --coverage',
       watch: 'jest --watch',
+      build: {
+        description: 'validates the built files',
+        script: 'babel-node dist-test/index.js',
+      },
     },
     build: {
       description: 'delete the dist directory and run all builds',
@@ -38,6 +42,7 @@ module.exports = {
         description: 'run the rollup build with sourcemaps',
         script: 'rollup --config --sourcemap --environment MINIFY',
       },
+      andTest: series.nps('build', 'test.build'),
     },
     lint: {
       description: 'lint the entire project',
@@ -68,7 +73,7 @@ module.exports = {
     },
     validate: {
       description: 'This runs several scripts to make sure things look good before committing or on clean install',
-      default: concurrent.nps('lint', 'build', 'test'),
+      default: concurrent.nps('lint', 'build.andTest', 'test'),
       examples: {
         description: 'Validates the examples folder',
         script: 'nps examples.withJest',


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This adds a test for the distributable files

<!-- Why are these changes necessary? -->
**Why**: #35 (make sure we don't break the way `glamorous` is exported/imported)

<!-- How were these changes implemented? -->
**How**: Copied a bunch of stuff from [`match-sorter`](https://github.com/kentcdodds/match-sorter)


<!-- feel free to add additional comments -->
Closes #35