### PR TITLE
feat(perf): exit early when filtering props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,6 +217,12 @@ function splitProps(
   const returnValue = {toForward: {}, cssOverrides: {}}
   if (!propsAreCssOverrides) {
     returnValue.cssOverrides = cssOverrides
+    if (typeof rootEl !== 'string') {
+      // if it's not a string, then we can forward everything
+      // (because it's a component)
+      returnValue.toForward = rest
+      return returnValue
+    }
   }
   return Object.keys(rest).reduce(
     (split, propName) => {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: This adds an `if` statement to exit early in the `splitProps` function

<!-- Why are these changes necessary? -->
**Why**: If the rootEl is a component, then we can forward all props to it without worrying about attaching props to DOM nodes. So we can skip the reduce function entirely.

<!-- How were these changes implemented? -->
**How**: Running the tests in watch mode and hitting random keys until they passed.


<!-- feel free to add additional comments -->
Helps with #43
