### PR TITLE
feat(HOC): add `withTheme` HOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,72 @@ const Title = glamorous.h1({
 </ThemeProvider>
 ```
 
+`glamorous` also exports a `withTheme` higher order component (HOC) so you can access your theme in any component!
+> Try this out in your browser [here](https://codesandbox.io/s/qYmJjE4jy)!
+
+```jsx
+import glamorous, {ThemeProvider,  withTheme} from glamorous
+
+// our main theme object
+const theme = {
+  main: {color: 'red'}
+}
+
+// a themed <Title> component
+const Title = glamorous.h1({
+  fontSize: '10px'
+}, (props, theme) => ({
+  color: theme.main.color
+}))
+
+// normal component that takes a theme prop
+const SubTitle = ({children, theme: {color}}) => (
+  <h3 style={{color}}>{children}</h3>
+);
+
+// extended component with theme prop
+const ThemedSubTitle = withTheme(SubTitle);
+
+<ThemeProvider theme={theme}>
+  <Title>Hello!</Title>
+  <ThemedSubTitle>from withTheme!</ThemedSubTitle>
+</ThemeProvider>
+```
+
+Or if you prefer decorator syntax:
+
+```jsx
+import React, {Component} from 'react';
+import glamorous, {ThemeProvider,  withTheme} from glamorous
+
+// our main theme object
+const theme = {
+  main: {color: 'red'}
+}
+
+// a themed <Title> component
+const Title = glamorous.h1({
+  fontSize: '10px'
+}, (props, theme) => ({
+  color: theme.main.color
+}))
+
+// extended component with theme prop
+@withTheme
+class SubTitle extends Component {
+  render() {
+    const {children, theme: {color}} = this.props;
+    return <h3 style={{color}}>{children}</h3>;
+  }
+}
+
+<ThemeProvider theme={theme}>
+  <Title>Hello!</Title>
+  <SubTitle>from withTheme!</SubTitle>
+</ThemeProvider>
+```
+> `withTheme` expects a `ThemeProvider` further up the render tree and will warn in `development` if one is not found!
+
 ### Server Side Rendering (SSR)
 
 Because both `glamor` and `react` support SSR, `glamorous` does too! I actually

--- a/src/__tests__/__snapshots__/with-theme.js.snap
+++ b/src/__tests__/__snapshots__/with-theme.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders a non-glamorous component with theme 1`] = `
+<div
+  style="padding:10px;"
+/>
+`;
+
+exports[`with theme prop of padding 10px 1`] = `
+<Parent>
+  <ThemeProvider
+    theme={
+      Object {
+        "padding": 10,
+      }
+    }
+  >
+    <ThemedComponent>
+      <Component
+        theme={
+          Object {
+            "padding": 10,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "padding": 10,
+            }
+          }
+        />
+      </Component>
+    </ThemedComponent>
+  </ThemeProvider>
+</Parent>
+`;
+
+exports[`with theme prop of padding 10px 2`] = `
+<Parent>
+  <ThemeProvider
+    theme={
+      Object {
+        "padding": 10,
+      }
+    }
+  >
+    <ThemedComponent>
+      <Child
+        theme={
+          Object {
+            "padding": 10,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "padding": 10,
+            }
+          }
+        />
+      </Child>
+    </ThemedComponent>
+  </ThemeProvider>
+</Parent>
+`;
+
+exports[`with theme prop of padding 20px 1`] = `
+<Parent>
+  <ThemeProvider
+    theme={
+      Object {
+        "padding": 20,
+      }
+    }
+  >
+    <ThemedComponent>
+      <Component
+        theme={
+          Object {
+            "padding": 20,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "padding": 20,
+            }
+          }
+        />
+      </Component>
+    </ThemedComponent>
+  </ThemeProvider>
+</Parent>
+`;
+
+exports[`without theme provider 1`] = `
+<Parent>
+  <ThemedComponent>
+    <Component
+      theme={Object {}}
+    >
+      <div />
+    </Component>
+  </ThemedComponent>
+</Parent>
+`;

--- a/src/__tests__/with-theme.js
+++ b/src/__tests__/with-theme.js
@@ -1,0 +1,130 @@
+/* eslint func-style:0 */
+import React, {Component} from 'react'
+import {render, mount} from 'enzyme'
+
+import withTheme from '../with-theme'
+import ThemeProvider, {CHANNEL} from '../theme-provider'
+import {PropTypes} from '../react-compat'
+
+const getMockedContext = unsubscribe => ({
+  [CHANNEL]: {
+    getState: () => {},
+    setState: () => {},
+    subscribe: () => unsubscribe,
+  },
+})
+
+test('renders a non-glamorous component with theme', () => {
+  const CompWithTheme = withTheme(({theme: {padding}}) => (
+    <div style={{padding}} />
+  ))
+  expect(
+    render(
+      <ThemeProvider theme={{padding: '10px'}}>
+        <CompWithTheme />
+      </ThemeProvider>,
+    ),
+  ).toMatchSnapshot()
+})
+
+test('theme properties updates get propagated down the tree', () => {
+  class Parent extends Component {
+    state = {
+      padding: 10,
+    }
+
+    render() {
+      return (
+        <ThemeProvider theme={{padding: this.state.padding}}>
+          <Child />
+        </ThemeProvider>
+      )
+    }
+  }
+
+  const Child = withTheme(({theme: {padding}}) => <div style={{padding}} />)
+  const wrapper = mount(<Parent />)
+  expect(wrapper).toMatchSnapshot(`with theme prop of padding 10px`)
+  wrapper.setState({padding: 20})
+  expect(wrapper).toMatchSnapshot(`with theme prop of padding 20px`)
+})
+
+test('works properly with classes', () => {
+  /* eslint-disable react/prefer-stateless-function */
+  class Child extends Component {
+    render() {
+      const {theme: {padding}} = this.props
+      return <div style={{padding}} />
+    }
+  }
+
+  Child.propTypes = {
+    theme: PropTypes.object,
+  }
+
+  const ChildWithTheme = withTheme(Child)
+
+  class Parent extends Component {
+    state = {
+      padding: 10,
+    }
+
+    render() {
+      return (
+        <ThemeProvider theme={{padding: this.state.padding}}>
+          <ChildWithTheme />
+        </ThemeProvider>
+      )
+    }
+  }
+
+  const wrapper = mount(<Parent />)
+  expect(wrapper).toMatchSnapshot(`with theme prop of padding 10px`)
+})
+
+test('pass through when no theme provider found up tree', () => {
+  /* eslint-disable no-console */
+  const originalWarn = console.warn
+  console.warn = jest.fn()
+
+  const Child = withTheme(() => <div />)
+  const Parent = () => <Child />
+  const wrapper = mount(<Parent />)
+
+  expect(wrapper).toMatchSnapshot(`without theme provider`)
+  expect(console.warn).toHaveBeenCalledTimes(1)
+  expect(console.warn).toHaveBeenCalledWith(
+    // eslint-disable-next-line max-len
+    `glamorous warning: Expected component called "Stateless Function" which uses withTheme to be within a ThemeProvider but none was found.`,
+  )
+  console.warn = originalWarn
+})
+
+test('does not warn when NODE_ENV is set to `production`', () => {
+  /* eslint-disable no-console */
+  const originalWarn = console.warn
+  console.warn = jest.fn()
+
+  const originalEnv = process.env.NODE_ENV
+  process.env.NODE_ENV = 'production'
+
+  const Child = withTheme(() => <div />)
+  const Parent = () => <Child />
+  mount(<Parent />)
+
+  expect(console.warn).not.toHaveBeenCalled()
+
+  console.warn = originalWarn
+  process.env.NODE_ENV = originalEnv
+})
+
+test('unsubscribes from theme updates on unmount', () => {
+  const Child = withTheme(() => <div />)
+  const unsubscribe = jest.fn()
+  const context = getMockedContext(unsubscribe)
+  const wrapper = mount(<ThemeProvider theme={{}}><Child /></ThemeProvider>, {
+    context,
+  })
+  wrapper.unmount()
+  expect(unsubscribe).toHaveBeenCalled()
+})

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import shouldForwardProperty from './should-forward-property'
 import domElements from './dom-elements'
 import {PropTypes} from './react-compat'
 import ThemeProvider, {CHANNEL} from './theme-provider'
+import withTheme from './with-theme'
 
 /**
  * This is the main export and the function that people
@@ -246,4 +247,4 @@ function joinClasses(...classes) {
 }
 
 export default glamorous
-export {ThemeProvider}
+export {ThemeProvider, withTheme}

--- a/src/with-theme.js
+++ b/src/with-theme.js
@@ -1,0 +1,56 @@
+import React, {Component} from 'react'
+
+import {CHANNEL} from './theme-provider'
+import {PropTypes} from './react-compat'
+
+function generateWarningMessage(componentName) {
+  // eslint-disable-next-line max-len
+  return `glamorous warning: Expected component called "${componentName}" which uses withTheme to be within a ThemeProvider but none was found.`
+}
+
+export default function withTheme(ComponentToTheme) {
+  class ThemedComponent extends Component {
+    state = {theme: {}}
+    setTheme = theme => this.setState({theme})
+
+    componentWillMount() {
+      if (!this.context[CHANNEL]) {
+        if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.warn(
+            generateWarningMessage(
+              ComponentToTheme.displayName ||
+                ComponentToTheme.name ||
+                'Stateless Function',
+            ),
+          )
+        }
+
+        return
+      }
+
+      this.setState({theme: this.context[CHANNEL].getState()})
+    }
+
+    componentDidMount() {
+      if (this.context[CHANNEL]) {
+        this.unsubscribe = this.context[CHANNEL].subscribe(this.setTheme)
+      }
+    }
+
+    componentWillUnmount() {
+      // cleanup subscription
+      this.unsubscribe && this.unsubscribe()
+    }
+
+    render() {
+      return <ComponentToTheme {...this.props} {...this.state} />
+    }
+  }
+
+  ThemedComponent.contextTypes = {
+    [CHANNEL]: PropTypes.object,
+  }
+
+  return ThemedComponent
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2410,6 +2410,10 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fast-memoize@^2.2.7:
+  version "2.2.7"
+  resolved "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.2.7.tgz#f145c5c22039cedf0a1d4ff6ca592ad0268470ca"
+
 fb-watchman@^1.8.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.2.tgz#a24cf47827f82d38fb59a69ad70b76e3b6ae7383"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Added a HOC (higher order component) called `withTheme` that exposes theme context as a prop to passed in component.

<!-- Why are these changes necessary? -->
**Why**:
It was requested in Issue #41 

<!-- How were these changes implemented? -->
**How**:
I first created a new file to contain the HOC, I then added to global exports. I also added tests.

<!-- feel free to add additional comments -->
There are a few comments in there as some things are unclear still. Mainly, what do we want to do when there is no context found (no ThemeProvider further up the tree). There is also some concern on naming of things. Not sure what you want the exported HOC class name to be.