### PR TITLE
feat(forwardProps): add forwardProps option

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "license": "MIT",
   "dependencies": {
     "brcast": "^1.1.6",
+    "fast-memoize": "^2.2.7",
     "html-tag-names": "^1.1.1",
-    "svg-tag-names": "^1.1.0",
     "react-html-attributes": "^1.2.1",
-    "fast-memoize": "^2.2.7"
+    "svg-tag-names": "^1.1.0"
   },
   "peerDependencies": {
     "glamor": ">=2",
@@ -51,8 +51,8 @@
     "commitizen": "^2",
     "common-tags": "^1.4.0",
     "cz-conventional-changelog": "^2.0.0",
-    "enzyme": "^2.8.0",
-    "enzyme-to-json": "^1.5.0",
+    "enzyme": "^2.8.1",
+    "enzyme-to-json": "^1.5.1",
     "eslint": "^3.17.0",
     "eslint-config-kentcdodds": "^12.0.0",
     "glamor": "^2.20.24",
@@ -64,10 +64,11 @@
     "nps-utils": "^1.1.2",
     "opt-cli": "^1.5.1",
     "prettier-eslint-cli": "^3.1.2",
-    "prop-types": "^15.5.6",
-    "react": "^15.5.3",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
     "react-addons-test-utils": "^15.5.1",
-    "react-dom": "^15.5.3",
+    "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4",
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allows you to pass custom props that are allowed 1`] = `
+.css-1r7lsit,
+[data-css-1r7lsit] {
+  padding: 1px;
+}
+
+<div
+  class="css-1r7lsit"
+  id="hello"
+/>
+`;
+
 exports[`allows you to specify the tag rendered by a component 1`] = `
 .css-110n7f9,
 [data-css-110n7f9] {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,4 +1,4 @@
-/* eslint func-style:0 */
+/* eslint func-style:0, react/prop-types:0 */
 import React from 'react'
 import * as glamor from 'glamor'
 import {render, mount} from 'enzyme'
@@ -244,4 +244,31 @@ test('ignores context if a theme props is passed', () => {
   const wrapper = mount(<Comp theme={{}} />, {context})
   wrapper.unmount()
   expect(unsubscribe).toHaveBeenCalledTimes(0)
+})
+
+test('allows you to pass custom props that are allowed', () => {
+  const MyComponent = jest.fn(function MyComponent({shouldRender, ...rest}) {
+    return shouldRender ? <div {...rest} /> : null
+  })
+  const MyStyledComponent = glamorous(MyComponent, {
+    forwardProps: ['shouldRender'],
+    rootEl: 'div',
+  })({
+    padding: 1,
+  })
+  expect(
+    render(
+      <MyStyledComponent shouldRender={true} otherThing={false} id="hello" />,
+    ),
+  ).toMatchSnapshotWithGlamor()
+  expect(MyComponent).toHaveBeenCalledTimes(1)
+  expect(MyComponent).toHaveBeenCalledWith(
+    {
+      shouldRender: true,
+      id: 'hello',
+      className: expect.any(String),
+    },
+    expect.any(Object),
+    expect.any(Object),
+  )
 })

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ import withTheme from './with-theme'
  * @param {Object} options helpful info for the GlamorousComponents
  * @return {Function} the glamorousComponentFactory
  */
-function glamorous(comp, {rootEl, displayName} = {}) {
+function glamorous(comp, {rootEl, displayName, forwardProps = []} = {}) {
   return glamorousComponentFactory
 
   /**
@@ -111,13 +111,21 @@ function glamorous(comp, {rootEl, displayName} = {}) {
 
     Object.assign(
       GlamorousComponent,
-      getGlamorousComponentMetadata({comp, styles, rootEl, displayName}),
+      getGlamorousComponentMetadata({
+        comp,
+        styles,
+        rootEl,
+        forwardProps,
+        displayName,
+      }),
     )
     return GlamorousComponent
   }
 }
 
-function getGlamorousComponentMetadata({comp, styles, rootEl, displayName}) {
+function getGlamorousComponentMetadata(
+  {comp, styles, rootEl, forwardProps, displayName},
+) {
   const componentsComp = comp.comp ? comp.comp : comp
   return {
     // join styles together (for anyone doing: glamorous(glamorous.a({}), {}))
@@ -128,6 +136,7 @@ function getGlamorousComponentMetadata({comp, styles, rootEl, displayName}) {
     // component in glamorous
     comp: componentsComp,
     rootEl: rootEl || componentsComp,
+    forwardProps,
     // set the displayName to something that's slightly more
     // helpful than `GlamorousComponent` :)
     displayName: displayName || `glamorous(${getDisplayName(comp)})`,
@@ -213,7 +222,7 @@ function extractGlamorStyles(className = '') {
 
 function splitProps(
   {css: cssOverrides = {}, ...rest},
-  {propsAreCssOverrides, rootEl},
+  {propsAreCssOverrides, rootEl, forwardProps},
 ) {
   const returnValue = {toForward: {}, cssOverrides: {}}
   if (!propsAreCssOverrides) {
@@ -227,7 +236,10 @@ function splitProps(
   }
   return Object.keys(rest).reduce(
     (split, propName) => {
-      if (shouldForwardProperty(rootEl, propName)) {
+      if (
+        forwardProps.indexOf(propName) !== -1 ||
+        shouldForwardProperty(rootEl, propName)
+      ) {
         split.toForward[propName] = rest[propName]
       } else if (propsAreCssOverrides) {
         split.cssOverrides[propName] = rest[propName]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1997,9 +1997,9 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-to-json@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-1.5.0.tgz#bb94f21346866d68378adc9b26856dd6e2bfa60b"
+enzyme-to-json@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-1.5.1.tgz#e34f4d126bb3f4696ce3800b51f9ed83df708799"
   dependencies:
     lodash.filter "^4.6.0"
     lodash.isnil "^4.0.0"
@@ -2009,9 +2009,9 @@ enzyme-to-json@^1.5.0:
     object-values "^1.0.0"
     object.entries "^1.0.3"
 
-enzyme@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-2.8.0.tgz#86cc1fc96e5cbd7695766dd6e89deb13a0aead51"
+enzyme@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-2.8.1.tgz#53891a75c8fe4d56582c113b3da45713b8215738"
   dependencies:
     cheerio "^0.22.0"
     function.prototype.name "^1.0.0"
@@ -2021,6 +2021,7 @@ enzyme@^2.8.0:
     object.assign "^4.0.4"
     object.entries "^1.0.3"
     object.values "^1.0.3"
+    prop-types "^15.5.4"
     uuid "^2.0.3"
 
 "errno@>=0.1.1 <0.2.0-0", errno@^0.1.3:
@@ -4960,9 +4961,9 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.2, prop-types@^15.5.6, prop-types@~15.5.0:
-  version "15.5.6"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.6.tgz#797a915b1714b645ebb7c5d6cc690346205bd2aa"
+prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
     fbjs "^0.8.9"
 
@@ -5049,14 +5050,14 @@ react-addons-test-utils@^15.5.1:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-dom@^15.5.3:
-  version "15.5.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.3.tgz#2ee127ce942df55da53111ae303316e68072b5c5"
+react-dom@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "~15.5.0"
+    prop-types "~15.5.7"
 
 react-html-attributes@^1.2.1:
   version "1.2.1"
@@ -5064,14 +5065,21 @@ react-html-attributes@^1.2.1:
   dependencies:
     html-element-attributes "^1.0.0"
 
-react@^15.5.3:
-  version "15.5.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.5.3.tgz#84055382c025dec4e3b902bb61a8697cc79c1258"
+react-test-renderer@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
+  dependencies:
+    fbjs "^0.8.9"
+    object-assign "^4.1.0"
+
+react@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
-    prop-types "^15.5.2"
+    prop-types "^15.5.7"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
**What**: This adds a `forwardProps` option to the `glamorous` function

**Why**: So if you're wrapping a component in `glamorous`, you can specify some props to forward, regardless of the `rootEl` you define.

**How**: TDD! Also I had to update some dependencies to get rid of annoying warnings from React :)
