### PR TITLE
Fix ...styles example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,14 +199,14 @@ render and return style objects. To learn more about what these style objects
 can look like, please take a look at the [`glamor`][glamor] documentation.
 
 ```jsx
-const MyStyledDiv = glamorous.div([
+const MyStyledDiv = glamorous.div(
   {
     margin: 1,
   },
   (props) => ({
     padding: props.noPadding ? 0 : 4,
   })
-])
+)
 
 <MyStyledDiv /> // styles applied: {margin: 1, padding: 4}
 <MyStyledDiv noPadding /> // styles applied: {margin: 1, padding: 0}


### PR DESCRIPTION
Hi, I was playing around with some of the examples in the README.md in CodeSandbox and noticed this.
Not sure if this is an error in the docs or a bug but removing the array fixed the issue.

[![CodeSandbox example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/Vm43o6kZX)

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: README.md

<!-- Why are these changes necessary? -->
**Why**: Example not working.

<!-- How were these changes implemented? -->
**How**: Remove array from example.


<!-- feel free to add additional comments -->
