### PR TITLE
Support SVG-specific attributes for all available SVG tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "brcast": "^2.0.0",
     "fast-memoize": "^2.2.7",
     "html-tag-names": "^1.1.1",
-    "react-html-attributes": "^1.2.2",
+    "react-html-attributes": "^1.3.0",
     "svg-tag-names": "^1.1.0"
   },
   "peerDependencies": {

--- a/src/__tests__/should-forward-property.test.js
+++ b/src/__tests__/should-forward-property.test.js
@@ -49,10 +49,20 @@ test('should forward a random react-specific attribute', () => {
 
 test("should not forward a valid css property with a 'div' tag", () => {
   validCssProps.forEach(cssProp =>
-    expect(shouldForwardProperty('div', cssProp)).toBeFalsy())
+    expect(shouldForwardProperty('div', cssProp)).toBeFalsy(),
+  )
 })
 
 test("should forward a valid css property with a 'svg' tag", () => {
   validCssProps.forEach(cssProp =>
-    expect(shouldForwardProperty('svg', cssProp)).toBeTruthy())
+    expect(shouldForwardProperty('svg', cssProp)).toBeTruthy(),
+  )
+})
+
+test("should forward the 'fill' property with a 'rect' tag", () => {
+  expect(shouldForwardProperty('rect', 'fill')).toBeTruthy()
+})
+
+test("should forward the 'cx' property with a 'circle' tag", () => {
+  expect(shouldForwardProperty('circle', 'cx')).toBeTruthy()
 })

--- a/src/should-forward-property.js
+++ b/src/should-forward-property.js
@@ -30,7 +30,7 @@ const isCustomAttribute = RegExp.prototype.test.bind(
 
 const isSvgTag = tagName => supportedSVGTagNames.indexOf(tagName) !== -1
 const isHtmlProp = (name, tagName) => {
-  let elementAttributes
+  let elementAttributes = []
 
   if (isSvgTag(tagName)) {
     // all SVG attributes supported by React are grouped under 'svg'
@@ -41,9 +41,7 @@ const isHtmlProp = (name, tagName) => {
 
   return (
     globalReactHtmlProps.indexOf(name) !== -1 ||
-    (elementAttributes === undefined ?
-      false :
-      elementAttributes.indexOf(name) !== -1)
+    elementAttributes.indexOf(name) !== -1
   )
 }
 const isCssProp = name => cssProps.indexOf(name) !== -1

--- a/src/should-forward-property.js
+++ b/src/should-forward-property.js
@@ -11,6 +11,7 @@ import reactHTMLAttributes from 'react-html-attributes'
 import reactProps from './react-props'
 
 const globalReactHtmlProps = reactHTMLAttributes['*']
+const supportedSVGTagNames = reactHTMLAttributes.elements.svg
 
 // these are valid attributes that have the
 // same name as CSS properties, and is used
@@ -18,21 +19,32 @@ const globalReactHtmlProps = reactHTMLAttributes['*']
 const cssProps = ['color', 'height', 'width']
 
 /* From DOMProperty */
-// eslint-disable-next-line max-len
-const ATTRIBUTE_NAME_START_CHAR = ':A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD'
+const ATTRIBUTE_NAME_START_CHAR =
+  // eslint-disable-next-line max-len
+  ':A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD'
 // eslint-disable-next-line max-len
 const ATTRIBUTE_NAME_CHAR = `${ATTRIBUTE_NAME_START_CHAR}\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040`
 const isCustomAttribute = RegExp.prototype.test.bind(
   new RegExp(`^(data|aria)-[${ATTRIBUTE_NAME_CHAR}]*$`),
 )
 
+const isSvgTag = tagName => supportedSVGTagNames.indexOf(tagName) !== -1
 const isHtmlProp = (name, tagName) => {
-  const elementAttributes = reactHTMLAttributes[tagName]
+  let elementAttributes
 
-  return globalReactHtmlProps.indexOf(name) !== -1 ||
+  if (isSvgTag(tagName)) {
+    // all SVG attributes supported by React are grouped under 'svg'
+    elementAttributes = reactHTMLAttributes.svg
+  } else {
+    elementAttributes = reactHTMLAttributes[tagName]
+  }
+
+  return (
+    globalReactHtmlProps.indexOf(name) !== -1 ||
     (elementAttributes === undefined ?
       false :
       elementAttributes.indexOf(name) !== -1)
+  )
 }
 const isCssProp = name => cssProps.indexOf(name) !== -1
 const isReactProp = name => reactProps.indexOf(name) !== -1
@@ -43,6 +55,6 @@ const shouldForwardProperty = (tagName, name) =>
   ((isHtmlProp(name, tagName) ||
     isReactProp(name) ||
     isCustomAttribute(name.toLowerCase())) &&
-    (tagName === 'svg' || !isCssProp(name)))
+    (!isCssProp(name) || isSvgTag(tagName)))
 
 export default memoize(shouldForwardProperty)

--- a/src/should-forward-property.js
+++ b/src/should-forward-property.js
@@ -30,13 +30,13 @@ const isCustomAttribute = RegExp.prototype.test.bind(
 
 const isSvgTag = tagName => supportedSVGTagNames.indexOf(tagName) !== -1
 const isHtmlProp = (name, tagName) => {
-  let elementAttributes = []
+  let elementAttributes
 
   if (isSvgTag(tagName)) {
     // all SVG attributes supported by React are grouped under 'svg'
     elementAttributes = reactHTMLAttributes.svg
   } else {
-    elementAttributes = reactHTMLAttributes[tagName]
+    elementAttributes = reactHTMLAttributes[tagName] || []
   }
 
   return (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This is an attempt to fix https://github.com/paypal/glamorous/issues/91. Currently, we only support SVG attributes on the `svg` element. This updates the library to support all of them.

<!-- Why are these changes necessary? -->
**Why**:
React supports many SVG attributes that need to be forwarded to SVG elements other than `svg`.

<!-- How were these changes implemented? -->
**How**:
Check if the tag belongs to a SVG element and if so, check if it's one of the React-supported SVG attributes. 

<!-- feel free to add additional comments -->
Currently, this branch is not passing all the tests because some HTML elements share the same tag names with some SVG elements. So don't merge it obviously. Let's discuss what's the best way to deal with situations like that.
