### PR TITLE
fix(typescript): fixed typings tests and typings for extended component

### DIFF
--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -24,7 +24,7 @@ const Divider = glamorous.span(
     "fontSize": "10px",
     "zIndex": "auto"
   },
-  (props, theme: { main: { color: string; }}) => ({
+  (props, theme: { main: { color: string; } }) => ({
     "color": theme.main.color,
   }),
 );
@@ -34,8 +34,8 @@ const SpanDivider = glamorous.span(
   {
     "fontSize": "10px",
   },
-  (props, theme) => ({
-    "color": theme,
+  (props, theme: { awesome: { color: string } }) => ({
+    "color": theme.awesome.color,
   }),
   {
     "fontWeight": 500,
@@ -44,7 +44,7 @@ const SpanDivider = glamorous.span(
     "fontFamily": "Roboto",
     "fontWeight": 500,
   },
-  (props, theme: { main: { color: string; }}) => ({
+  (props, theme: { main: { color: string; } }) => ({
     "color": theme.main.color,
   }),
 );
@@ -58,7 +58,7 @@ const DividerInsideDivider = glamorous(Divider)(
   {
     "fontSize": "10px",
   },
-  (props, theme: { main: { color: string; }}) => ({
+  (props, theme: { main: { color: string; } }) => ({
     "color": theme.main.color,
   }),
 );
@@ -86,8 +86,8 @@ export class AirBalloon extends React.Component<{}, {}> {
   public render() {
     return (
       <Divider innerRef={(
-          c: HTMLSpanElement
-        ) => { this.spanElem = c; }}>
+        c: HTMLSpanElement
+      ) => { this.spanElem = c; }}>
         Hello
         <SpanDivider>
           Span Divider
@@ -100,7 +100,7 @@ export class AirBalloon extends React.Component<{}, {}> {
 class Test extends React.Component<object, object> {
   private div: HTMLDivElement
   render() {
-    return <div ref={(c) => { this.div = c}}/>
+    return <div ref={(c) => { this.div = c }} />
   }
 }
 

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -11,6 +11,7 @@ import {
   StyledFunction,
   GlamorousComponent,
 } from './styled-function'
+import { CSSProperties } from './css-properties'
 
 export { StyledFunction }
 
@@ -26,9 +27,9 @@ export interface GlamorousInterface extends HTMLGlamorousInterface, SVGGlamorous
       | React.ComponentClass<P>
       | React.StatelessComponent<P>,
     options?: GlamorousOptions
-  ): StyledFunction<P, React.CSSProperties | React.SVGAttributes<any>>
+  ): StyledFunction<P, CSSProperties | React.SVGAttributes<any>>
 
-  Div: React.StatelessComponent<React.CSSProperties>
+  Div: React.StatelessComponent<CSSProperties>
   Svg: React.StatelessComponent<React.SVGAttributes<any>>
 }
 


### PR DESCRIPTION
**What**:
There are two little fixes in this PR.

Firstly, I forgot to apply new CSSProperties typings (#94) to extended components (e.g. `const MyAwesomeLink = glamorous(MyLink)({ color: 'red' })`). It was still using the React ones. Fixed now. Sorry for that, overlooked it :).

Secondly, the tests were broken. Actually, the new typings revealed it (yey 😀). Fixed.

**Why**:
Because we want good typings

**How**:
Pretty easily! See the commits.

@luke-john @sammkj Would you review it :)?

PS: @luke-john I don't know why, but I can't you add as a reviewer, weird 😕.