### PR TITLE
docs(readme): link to glamorous-native project

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,17 @@ const {ThemeProvider} = glamorous
 </script>
 ```
 
+### React Native
+
+`glamorous` offers a version for React Native projects called `glamorous-native`.
+
+```js
+npm install glamorous-native --save
+```
+
+You can learn more at the [glamorous-native project][glamorous-native].
+
+
 ## Video Intro :tv:
 
 <a href="https://youtu.be/lmrQTpJ_3PM" title="glamorous walkthrough">
@@ -946,3 +957,4 @@ MIT
 [unknown-prop-warning]: https://facebook.github.io/react/warnings/unknown-prop.html
 [babel-plugin-module-resolver]: https://github.com/tleunen/babel-plugin-module-resolver
 [resolve-alias]: https://webpack.js.org/configuration/resolve/#resolve-alias
+[glamorous-native]: https://github.com/robinpowered/glamorous-native


### PR DESCRIPTION
Prepares the README with a link to `glamorous-native` (re https://github.com/paypal/glamorous/issues/7#issuecomment-301961710)

This is introduced as a subsection to the installation documentation (taking a cue from `redux`'s complimentary `react-redux` package [in their README](https://github.com/reactjs/redux#complementary-packages)).

Let me know if there's anything else to add, or if should get its own section with any additional content.

If we were to do it differently, I could see a "Complimentary Packages" section, but perhaps in the future if more sibling packages surface.

## Merge Requirements

- [ ] Officially release `v1.0.0` of `glamorous-react`