### PR TITLE
Add type for `css` prop

### DIFF
--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -10,6 +10,7 @@ import {
 import {
   StyledFunction,
   GlamorousComponent,
+  ExtraGlamorousProps,
 } from './styled-function'
 import { CSSProperties } from './css-properties'
 
@@ -23,14 +24,14 @@ export interface GlamorousOptions {
 
 export interface GlamorousInterface extends HTMLGlamorousInterface, SVGGlamorousInterface {
   <P>(
-    component: 
+    component:
       | React.ComponentClass<P>
       | React.StatelessComponent<P>,
     options?: GlamorousOptions
   ): StyledFunction<P, CSSProperties | React.SVGAttributes<any>>
 
-  Div: React.StatelessComponent<CSSProperties>
-  Svg: React.StatelessComponent<React.SVGAttributes<any>>
+  Div: React.StatelessComponent<CSSProperties & ExtraGlamorousProps>
+  Svg: React.StatelessComponent<React.SVGAttributes<any> & ExtraGlamorousProps>
 }
 
 interface ThemeProps {

--- a/typings/styled-function.d.ts
+++ b/typings/styled-function.d.ts
@@ -1,3 +1,5 @@
+import { CSSProperties } from './css-properties'
+
 /**
  * `glamorousComponentFactory` returns a ComponentClass
  *
@@ -8,7 +10,7 @@ export type GlamorousComponent<P> = React.ComponentClass<P & ExtraGlamorousProps
 
 /**
  * StaticStyles are objects of CSS Properties.
- * 
+ *
  * @see {@link https://github.com/paypal/glamorous/blob/master/src/create-glamorous.js#L28-L131}
  */
 export type StaticStyles<Properties> = Partial<Properties>
@@ -16,7 +18,7 @@ export type StaticStyles<Properties> = Partial<Properties>
 /**
  * DynamicStyledFunction generates styles based on props
  * and themes.
- * 
+ *
  * @see {@link https://github.com/paypal/glamorous/blob/master/src/create-glamorous.js#L28-L131}
  */
 export type DynamicStyledFunction<Properties, CustomProps> = (
@@ -46,7 +48,8 @@ type Styles<Properties, CustomProps> = Array<DynamicStyledFunction<Properties, C
 // d,d,d
 
 export interface ExtraGlamorousProps {
-  innerRef?: (instance: any) => void
+  innerRef?: (instance: any) => void;
+  css?: CSSProperties;
 }
 
 export interface StyledFunction<Props, Properties> {


### PR DESCRIPTION
This is necessary for certain properties to work within the `css` prop object, such as `flexDirection`. Otherwise, you need to do something like this:

```jsx
 <Div css={{ flexDirection: 'row' as 'row', }}>My Div</Div>
```

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Typescript support

<!-- Why are these changes necessary? -->
**Why**:
Otherwise, weird TS errors when using certain properties within `css`

<!-- How were these changes implemented? -->
**How**:
Recursive type for `css`

<!-- feel free to add additional comments -->
