### PR TITLE
[WIP] test($typescript): Added test for when generating definition files

### DIFF
--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
 import glamorous, { ThemeProvider } from "../";
 
+// Needed if generating definition files
+// https://github.com/Microsoft/TypeScript/issues/5938
+import * as Unused from "../typings/styled-function"
+export { Unused }
+
 // static styles
 const Static = glamorous.div({
   "fontSize": 20,
@@ -121,3 +126,6 @@ const StatelessToWrap: React.StatelessComponent<object> = () => (
 )
 
 const WrappedStateless = glamorous(StatelessToWrap)({})
+
+// Exported Component (for testing declaration generation)
+export const ExportedComponent = glamorous.span({});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "allowJs": false,
+        "declaration": true,
         "inlineSources": true,
         "jsx": "react",
         "module": "commonjs",


### PR DESCRIPTION
[Work In Progress]
Doesn't make a lot of sense to land this until documentation also exists in Readme.

Also if anyone has any ideas on how to solve this in another way that would be great.

**What**:
Added a test for usage when generating definition files.

This is a bit of an odd test as the user is unlikely to know how to resolve this issue if they hit up against it.

It should be documented along with the typescript usage.

**Why**:
By default this doesn't work due to an issue with typescript.
https://github.com/Microsoft/TypeScript/issues/5938

**How**:
Adding flag to test typescript compiler options to create definitions.


**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [ ] Code complete
- [ ] Added myself to contributors table N/A
- [x] Followed the commit message format 

Have not added documentation as there is not currently typescript usage documentation in the readme.  Will open up a following pr to address https://github.com/paypal/glamorous/issues/83 shortly.
