### PR TITLE
docs($typescript): added typescript usage notes and known issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ npm install glamorous-native --save
 
 You can learn more at the [glamorous-native project][glamorous-native].
 
+### Typescript
+
+`glamorous` includes typescript definition files.
+
+For usage notes and known issues see [other/TYPESCRIPT_USAGE.md][typescript-usage].
 
 ## Video Intro :tv:
 
@@ -960,3 +965,4 @@ MIT
 [babel-plugin-module-resolver]: https://github.com/tleunen/babel-plugin-module-resolver
 [resolve-alias]: https://webpack.js.org/configuration/resolve/#resolve-alias
 [glamorous-native]: https://github.com/robinpowered/glamorous-native
+[typescript-usage]: https://github.com/paypal/glamorous/blob/master/other/TYPESCRIPT_USAGE.md

--- a/other/TYPESCRIPT_USAGE.md
+++ b/other/TYPESCRIPT_USAGE.md
@@ -4,6 +4,26 @@ The current bundled typescript definitions are incomplete and based around the n
 
 Pull requests to improve them are welcome and appreciated. If you've never contributed to open source before, then you may find [this free video course](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github) helpful.
 
+## Complete support
+
+### Dynamic styles
+
+To use dynamic styles with custom props use generics. Example:
+
+```ts
+const MyStyledDiv = glamorous.div<{noPadding?: boolean}>(
+  {
+    margin: 1,
+  },
+  props => ({
+    padding: props.noPadding ? 0 : 4,
+  })
+)
+
+<MyStyledDiv /> // styles applied: {margin: 1, padding: 4}
+<MyStyledDiv noPadding /> // styles applied: {margin: 1, padding: 0}
+```
+
 ## Incomplete support
 
 ### CSS property safety

--- a/other/TYPESCRIPT_USAGE.md
+++ b/other/TYPESCRIPT_USAGE.md
@@ -60,6 +60,6 @@ Possible support via [glamors typings](https://github.com/threepointone/glamor/b
 When using glamorous in a library that you are generating definition files for you will need to include the following import and export to get around a typescript issue [Microsoft/TypeScript/issues/5938](https://github.com/Microsoft/TypeScript/issues/5938).
 
 ```ts
-import * as Unused from "glamorous/typings/styled-function"
+import glamorous, { ExtraGlamorousProps as Unused } from "glamorous"
 export { Unused }
 ```

--- a/other/TYPESCRIPT_USAGE.md
+++ b/other/TYPESCRIPT_USAGE.md
@@ -1,0 +1,45 @@
+# Typescript Usage
+
+The current bundled typescript definitions are incomplete and based around the needs of the developers who contributed them.
+
+Pull requests to improve them are welcome and appreciated. If you've never contributed to open source before, then you may find [this free video course](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github) helpful.
+
+## Incomplete support
+
+### CSS property safety
+
+* pseudo-class
+* pseudo-element
+* Relational CSS Selectors
+* Media Queries
+
+All of these work, however you only get typesafety and intellisense on simple css key props (see the [css typings](https://github.com/paypal/glamorous/blob/master/typings/css-properties.d.ts)).
+
+In the future this may become possible with [Microsoft/TypeScript#6579](https://github.com/Microsoft/TypeScript/issues/6579)
+
+Alternatively support for full typesafety would be possible using patterns along the lines of http://typestyle.io/.
+
+### Built-in DOM component factories
+
+Currently support is limited to `div` and `svg`.
+
+## Unknown Support
+
+### Animations
+
+Possible support via [glamors typings](https://github.com/threepointone/glamor/blob/master/index.d.ts)
+
+## No Support
+
+* built-in GlamorousComponents
+
+## Known Issues
+
+### Generating Definition files
+
+When using glamorous in a library that you are generating definition files for you will need to include the following import and export to get around a typescript issue [Microsoft/TypeScript/issues/5938](https://github.com/Microsoft/TypeScript/issues/5938).
+
+```ts
+import * as Unused from "glamorous/typings/styled-function"
+export { Unused }
+```


### PR DESCRIPTION
closes #83 

**What**:
Added usage notes and known issues for typescript

**Why**:
The current bundled typescript definitions are incomplete and based around the needs of the developers who contributed them.

Whilst this is true of the definitions of many non typescript projects, it could still be a pain point for consumers.

**How**:
Based on feedback of #83 

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [ ] Tests N/A
- [ ] Code complete N/A
- [x] Followed the commit message format
