### PR TITLE
fix($typescript): Add ExtraGlamorousProps type as top-level export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ coverage
 dist
 .opt-in
 .opt-out
+test-ts
 typings/*.js
 *.log

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "nps",
     "test": "nps test",
-    "test:ts": "tsc -p ./tsconfig.json",
+    "test:ts": "(tsc -p ./tsconfig.json && rimraf test-ts) || rimraf test-ts",
     "commitmsg": "opt --in commit-msg --exec \"validate-commit-msg\"",
     "precommit": "lint-staged && opt --in pre-commit --exec \"npm start validate\""
   },
@@ -71,6 +71,7 @@
     "react-addons-test-utils": "^15.5.1",
     "react-dom": "^15.5.4",
     "react-test-renderer": "^15.5.4",
+    "rimraf": "^2.6.1",
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 import glamorous, { ThemeProvider } from "../";
 
+// Needed if generating definition files
+// https://github.com/Microsoft/TypeScript/issues/5938
+import { ExtraGlamorousProps } from "../";
+
 // static styles
 const Static = glamorous.div({
   "fontSize": 20,
@@ -121,3 +125,6 @@ const StatelessToWrap: React.StatelessComponent<object> = () => (
 )
 
 const WrappedStateless = glamorous(StatelessToWrap)({})
+
+// Exported Component (for testing declaration generation)
+export const ExportTest = glamorous.div({})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,17 @@
 {
     "compilerOptions": {
         "allowJs": false,
+        "declaration": true,
         "inlineSources": true,
         "jsx": "react",
         "module": "commonjs",
         "moduleResolution": "node",
-        "noEmit": true,
+        "noEmit": false,
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "noUnusedLocals": false,
         "noUnusedParameters": false,
+        "outDir": "./test-ts",
         "removeComments": false,
         "sourceMap": true,
         "strictNullChecks": true,

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -14,7 +14,7 @@ import {
 } from './styled-function'
 import { CSSProperties } from './css-properties'
 
-export { StyledFunction }
+export { StyledFunction, ExtraGlamorousProps }
 
 export interface GlamorousOptions {
   displayName: string


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
This adds the `ExtraGlamorousProps` type as a top-level export and adds a test for the underlying TypeScript issue it works around.

<!-- Why are these changes necessary? -->
**Why**:
This fixes issues when using TypeScript with `"declaration": true` in combination with webpack.

Original TypeScript issue: https://github.com/Microsoft/TypeScript/issues/5938

> [ts] Exported variable 'StyledPromiseCard' has or is using name 'ExtraGlamorousProps' from external module "[...]/node_modules/glamorous/typings/styled-function" but cannot be named

One workaround of this issue is to explicitly import the misbehaving type:
```ts
import glamorous from 'glamorous'
import { ExtraGlamorousProps } from 'glamorous/typings/styled-function'
```
This does however break the module resolution in our webpack build for Node.JS and throws "Module not found" errors.
With this PR, the type can now be imported directly from "glamorous":

```ts
import glamorous, { ExtraGlamorousProps } from 'glamorous'
```

<!-- How were these changes implemented? -->
**How**:
To make the test work completely, the TypeScript test had to actually emit files, otherwise the error case could not be reproduced. Added `rimraf` as an explicit dependency to clean up after the test.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation should be added to https://github.com/paypal/glamorous/pull/122
- [x] Tests
- [x] Code complete
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
- [x] Followed the commit message format <!-- this is optional as well, we can fix it for you when we merge your PR, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
