### PR TITLE
feat(context): add dynamic style context support

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -143,6 +143,17 @@ exports[`sanity test 1`] = `
 />
 `;
 
+exports[`should accept user defined contextTypes 1`] = `
+.css-svxepe,
+[data-css-svxepe] {
+  font-size: 24px;
+}
+
+<div
+  class="css-svxepe"
+/>
+`;
+
 exports[`style objects can be arrays and glamor will merge those 1`] = `
 @media (max-width: 640px) {
   .css-1bzhvkr,

--- a/src/__tests__/__snapshots__/theme-provider.js.snap
+++ b/src/__tests__/__snapshots__/theme-provider.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not override user defined theme contexts 1`] = `
+.css-svxepe,
+[data-css-svxepe] {
+  font-size: 24px;
+}
+
+<div
+  class="css-svxepe"
+/>
+`;
+
 exports[`merges nested themes 1`] = `
 .css-mhpxxj,
 [data-css-mhpxxj] {
@@ -44,6 +55,18 @@ exports[`merges nested themes 1`] = `
     </div>
   </ThemeProvider>
 </div>
+`;
+
+exports[`monkey-patches \`theme\` into user defined context 1`] = `
+.css-2y5zek,
+[data-css-2y5zek] {
+  font-size: 36px;
+  color: blue;
+}
+
+<div
+  class="css-2y5zek"
+/>
 `;
 
 exports[`renders a component with theme 1`] = `

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -5,6 +5,7 @@ import {render, mount} from 'enzyme'
 import * as jestGlamorReact from 'jest-glamor-react'
 import {oneLine} from 'common-tags'
 import glamorous from '../'
+import {PropTypes} from '../react-compat'
 
 import {CHANNEL} from '../constants'
 
@@ -278,7 +279,7 @@ test('renders a component with theme properties', () => {
     {
       color: 'red',
     },
-    (props, theme) => ({padding: theme.padding}),
+    (props, {theme}) => ({padding: theme.padding}),
   )
   expect(
     render(<Comp theme={{padding: '10px'}} />),
@@ -291,7 +292,7 @@ test('in development mode the theme is frozen and cannot be changed', () => {
     {
       color: 'red',
     },
-    (props, theme) => {
+    (props, {theme}) => {
       expect(() => {
         theme.foo = 'bar'
       }).toThrow()
@@ -309,7 +310,7 @@ test('in production mode the theme is not frozen and can be changed', () => {
     {
       color: 'red',
     },
-    (props, theme) => {
+    (props, {theme}) => {
       expect(() => {
         theme.foo = 'bar'
       }).not.toThrow()
@@ -325,7 +326,7 @@ test('passes an updated theme when theme prop changes', () => {
     {
       color: 'red',
     },
-    (props, theme) => ({padding: theme.padding}),
+    (props, {theme}) => ({padding: theme.padding}),
   )
   const wrapper = mount(<Comp theme={{padding: 10}} />)
   expect(wrapper).toMatchSnapshotWithGlamor(`with theme prop of padding 10px`)
@@ -403,4 +404,19 @@ test('can accept classNames instead of style objects', () => {
     'extra-thing',
   )
   expect(render(<Comp />)).toMatchSnapshotWithGlamor()
+})
+
+test('should accept user defined contextTypes', () => {
+  const Child = glamorous.div((props, context) => ({
+    fontSize: context.fontSize,
+  }))
+  Child.contextTypes = {
+    fontSize: PropTypes.number,
+  }
+
+  const context = {
+    fontSize: 24,
+  }
+
+  expect(render(<Child />, {context})).toMatchSnapshotWithGlamor()
 })

--- a/src/__tests__/tiny.js
+++ b/src/__tests__/tiny.js
@@ -31,6 +31,6 @@ test('should pass glam object prop', () => {
       id: 'hey-there',
       theme, // this is just insidental because we have a theme prop
     },
-    theme,
+    {theme},
   )
 })

--- a/src/get-glamor-classname.js
+++ b/src/get-glamor-classname.js
@@ -25,14 +25,14 @@ function extractGlamorStyles(className = '') {
 
 export default getGlamorClassName
 
-function getGlamorClassName(styles, props, cssOverrides, theme) {
+function getGlamorClassName(styles, props, cssOverrides, context) {
   let className, current
   const mappedArgs = []
   const nonGlamorClassNames = []
   for (let i = 0; i < styles.length; i++) {
     current = styles[i]
     if (typeof current === 'function') {
-      mappedArgs.push(current(props, theme))
+      mappedArgs.push(current(props, context))
     } else if (typeof current === 'string') {
       className = getGlamorStylesFromClassName(current)
       if (className) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: `context` is now accessible in dynamic style functions

```js
const MyDiv = glamorous.div(
  (props, context) => ({ /* style from context */ })
)
MyDiv.contextTypes = { /* user context types */ }
```

<!-- Why are these changes necessary? -->
**Why**: See goals in #125, previously `context` was inaccessible by `glamorous` dynamic styles

<!-- How were these changes implemented? -->
**How**: The `GlamorousComponent` now [passes `context` to `getGlamorClassName`](https://github.com/robinpowered/glamorous/blob/c96f7aaf30b2a7d7910d6cb44f9ba217397f9fd5/src/create-glamorous.js#L103) instead of `theme`, which [passes the `context` along to the dynamic style function](https://github.com/robinpowered/glamorous/blob/c96f7aaf30b2a7d7910d6cb44f9ba217397f9fd5/src/get-glamor-classname.js#L35).

The `theme` is still in the picture: we [add it to the context](https://github.com/robinpowered/glamorous/blob/c96f7aaf30b2a7d7910d6cb44f9ba217397f9fd5/src/create-glamorous.js#L96) only if the `context` does not already contain a `theme` (this would happen if the user has a `theme` in their `context`).



## Feedback requested prior to merging

The user is now able to provide their own `contextTypes`:

```js
const MyDiv = glamorous.div(
  (props, context) => ({ /* style from context */ })
)
MyDiv.contextTypes = { /* user context types */ }
// oh no! they overwrote the contextTypes that we wrote!
```

We still ultimately want `CHANNEL` to be defined on the `GlamorousComponent`'s `contextTypes` definition. 

[Here's the current solution](https://github.com/robinpowered/glamorous/blob/c96f7aaf30b2a7d7910d6cb44f9ba217397f9fd5/src/create-glamorous.js#L122-L146):
I have `Object.defineProperty` defining a custom `get` and `set` rule on `GlamorousComponent.contextTypes`, such that we can always append our `CHANNEL` onto the `contextTypes`. **We don't want to lose our original context definition.**

When the user assignes `TheirGlamorousComponent.contextTypes = ...`, it [updates a private local variable `userDefinedContextTypes`](https://github.com/robinpowered/glamorous/blob/c96f7aaf30b2a7d7910d6cb44f9ba217397f9fd5/src/create-glamorous.js#L132-L134).

When React reads the component's `contextTypes`, [the custom `getter` returns a merged object of the user's `contextTypes` and glamorous'' `contextTypes`](https://github.com/robinpowered/glamorous/blob/c96f7aaf30b2a7d7910d6cb44f9ba217397f9fd5/src/create-glamorous.js#L135-L145).

**This is has a bit of magic to it 🎩 🐰 , anyone have thoughts for a more straightforward approach?**

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [ ] Code complete (**pending feedback**)
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
- [x] Followed the commit message format <!-- this is optional as well, we can fix it for you when we merge your PR, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
