### PR TITLE
feat(className): add displayName to the className

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,10 +499,15 @@ const myGlamorousComponentFactory = glamorous(
 )
 ```
 
+> Note: the `displayName` can also included in the className that your
+> components are given which makes the development experience a bit nicer.
+> To enable this see the section about `config`.
+> This will likely be enabled by default in the next major change.
+
 And now all components created by the `myGlamorousComponentFactory` will have
 the `displayName` of `MyGlamorousComponent`.
 
-There is also a [babel plugin](https://www.npmjs.com/package/babel-plugin-glamorous-displayname) that can monkey-patch the `displayName` onto
+There is also a [babel plugin][babel-displayname] that can monkey-patch the `displayName` onto
 the components that you create from your component factory.
 
 
@@ -688,6 +693,40 @@ class SubTitle extends Component {
 </ThemeProvider>
 ```
 > `withTheme` expects a `ThemeProvider` further up the render tree and will warn in `development` if one is not found!
+
+### Config
+
+You can configure glamorous globally with the `config` object which you can
+access via `glamorous.config`.
+
+#### useDisplayNameInClassName
+
+Defaults to `false` (will default to `true` in a future major release).
+This should _only_ be used for debugging purposes. It is strongly discouraged
+from referencing this className in your CSS due to the level of indirection that
+will add (making it easier for you to break something when refactoring in the
+future).
+
+Example:
+
+```jsx
+import glamorous from 'glamorous'
+glamorous.config.useDisplayNameInClassName = true
+
+const MyComponent = props => <div {...props} />
+const myGlamorousComponentFactory = glamorous(
+  MyComponent,
+  {displayName: 'MyGlamorousComponent'}
+)
+
+const MyGlamorousComponent = myGlamorousComponentFactory()
+<MyGlamorousComponent />
+// renders <div class="css-nil MyGlamorousComponent" />
+```
+
+If you don't want to provide the `displayName` for all of your components, then
+you can use [this babel-plugin][babel-displayname]. Otherwise, the className
+will be simply: `glamorous(MyComponent)`
 
 ### Context
 
@@ -899,6 +938,10 @@ const MyResponsiveDiv = glamorous.div({
 ```
 </details>
 
+## Related projects
+
+- [babel-plugin-glamorous-displayname][babel-displayname]: Automatically adds a `displayName` to your glamorous components for a better debugging experience.
+
 ## Users
 
 Who uses `glamorous`? See [other/USERS.md](https://github.com/paypal/glamorous/blob/master/other/USERS.md) and add yourself if you use `glamorous`!
@@ -1031,3 +1074,4 @@ MIT
 [glamorous-native]: https://github.com/robinpowered/glamorous-native
 [typescript-usage]: https://github.com/paypal/glamorous/blob/master/other/TYPESCRIPT_USAGE.md
 [gwc]: https://girlswhocode.com/
+[babel-displayname]: https://www.npmjs.com/package/babel-plugin-glamorous-displayname

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -39,6 +39,12 @@ exports[`can accept classNames instead of style objects 1`] = `
 />
 `;
 
+exports[`can be configured to use the displayName in the className 1`] = `
+<div
+  class="css-nil Hi-There"
+/>
+`;
+
 exports[`can use pre-glamorous components with css attributes 1`] = `
 .css-1t62idy,
 [data-css-1t62idy] {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -179,9 +179,19 @@ test('falls back to `unknown` if name cannot be inferred', () => {
 
 test('allows you to specify a displayName', () => {
   const MyComp = glamorous(props => <div {...props} />, {
-    displayName: 'HiThere',
+    displayName: 'Hi There',
   })()
-  expect(MyComp.displayName).toBe('HiThere')
+  expect(MyComp.displayName).toBe('Hi There')
+})
+
+test('can be configured to use the displayName in the className', () => {
+  const original = glamorous.config.useDisplayNameInClassName
+  glamorous.config.useDisplayNameInClassName = true
+  const MyComp = glamorous(props => <div {...props} />, {
+    displayName: 'Hi There',
+  })()
+  expect(render(<MyComp />)).toMatchSnapshotWithGlamor()
+  glamorous.config.useDisplayNameInClassName = original
 })
 
 test('will not forward `color` to a div', () => {

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -7,22 +7,26 @@ import {PropTypes} from './react-compat'
 import {CHANNEL} from './constants'
 import getGlamorClassName from './get-glamor-classname'
 
-export default function createGlamorous(splitProps) {
+export default createGlamorous
+
+function createGlamorous(splitProps) {
+  // TODO: in a breaking version, make this default to true
+  glamorous.config = {useDisplayNameInClassName: false}
+
+  return glamorous
+
   /**
-   * This is the main export and the function that people
-   * interact with most directly.
-   *
-   * It accepts a component which can be a string or
-   * a React Component and returns
-   * a "glamorousComponentFactory"
-   * @param {String|ReactComponent} comp the component to render
-   * @param {Object} options helpful info for the GlamorousComponents
-   * @return {Function} the glamorousComponentFactory
-   */
-  return function glamorous(
-    comp,
-    {rootEl, displayName, forwardProps = []} = {},
-  ) {
+  * This is the main export and the function that people
+  * interact with most directly.
+  *
+  * It accepts a component which can be a string or
+  * a React Component and returns
+  * a "glamorousComponentFactory"
+  * @param {String|ReactComponent} comp the component to render
+  * @param {Object} options helpful info for the GlamorousComponents
+  * @return {Function} the glamorousComponentFactory
+  */
+  function glamorous(comp, {rootEl, displayName, forwardProps = []} = {}) {
     return glamorousComponentFactory
 
     /**
@@ -97,11 +101,15 @@ export default function createGlamorous(splitProps) {
             theme,
             this.context,
           )
+          const debugClassName = glamorous.config.useDisplayNameInClassName ?
+            cleanClassname(GlamorousComponent.displayName) :
+            ''
+          const className = `${fullClassName} ${debugClassName}`.trim()
 
           return React.createElement(GlamorousComponent.comp, {
             ref: props.innerRef,
             ...toForward,
-            className: fullClassName,
+            className,
           })
         }
       }
@@ -189,4 +197,8 @@ export default function createGlamorous(splitProps) {
       comp :
       comp.displayName || comp.name || 'unknown'
   }
+}
+
+function cleanClassname(className) {
+  return className.replace(/ /g, '-').replace(/[^A-Za-z0-9\-_]/g, '_')
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,8 @@ const glamorous = createGlamorous(splitProps)
 Object.assign(
   glamorous,
   domElements.reduce((getters, tag) => {
+    // TODO: next breaking change, let's make
+    // the `displayName` be: `glamorous.${tag}`
     getters[tag] = glamorous(tag)
     return getters
   }, {}),


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Closes #137

<!-- Why are these changes necessary? -->
**Why**: This makes it easier to know which elements map to which glamorous components.

<!-- How were these changes implemented? -->
**How**:
- Change the `className` to include the `GlamorousComponent.className`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->
- [x] Followed the commit message format <!-- this is optional as well, we can fix it for you when we merge your PR, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
