### PR TITLE
feat(exports): export internal getGlamorClassName function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import withTheme from './with-theme'
 import ThemeProvider from './theme-provider'
 import createGlamorous from './create-glamorous'
 import splitProps from './split-props'
+import getGlamorClassName from './get-glamor-classname'
 
 const glamorous = createGlamorous(splitProps)
 
@@ -58,4 +59,4 @@ function capitalize(s) {
 glamorous.default = glamorous
 
 export default glamorous
-export {ThemeProvider, withTheme}
+export {ThemeProvider, withTheme, getGlamorClassName}


### PR DESCRIPTION
**What**: Exporting the internal `getGlamorClassName` function.

**Why**: I'm working on testing glamorous components with [WebdriverIO](http://webdriver.io/), it would be very helpful to me to have generated classnames.

**How**: See **What**.

**Checklist**:

- [ ] Documentation
- [ ] Tests N/A
- [x] Code complete
- [ ] Added myself to contributors table (TBD)
- [x] Followed the commit message forma

**Other**:

I'm open to other suggestions on how to do what I want here. This also unfortunately exports an internal API which can make future breaking changes more difficult if you're shy about releasing major versions. Maybe we should make the `getGlamorClassName` function accept a single object argument which is destructured before merging this PR?
