### PR TITLE
feat(glamorous): withProps factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,39 @@ const MyStyledDiv = glamorous.div(
 <MyStyledDiv /> // styles applied: {padding-top: 1, padding-right: 2, padding-bottom: 3, padding-left: 4} and anything coming from `extra-thing`.
 ```
 
+##### withProps
+
+The `glamorousComponentFactory` has a `withProps` property, which is another
+factory function accepting any number of property object arguments to be applied
+to the `GlamorousComponent`. Just like styles, these can either be property objects
+or functions wich are invoked with `props` on every render and return property objects.
+The result is a `GlamorousComponent` with the specified props:
+
+```jsx
+const StyledTextInput = glamorous.input.withProps({type: 'text'})({
+  padding: 10
+})
+
+const StyledValidatedTextInput = glamorous(MyStyledInput).withProps(
+  props => {
+    if (props.creditCard) {
+      return {
+        pattern: /([0-9]{4}){4}/
+      }
+    }
+    return null
+  }
+)
+
+<StyledTextInput />
+// renders: <input type="text" />
+// styles applied: {padding: 10}
+
+<StyledValidatedTextInput creditCard />
+// renders: <input type="text" pattern="/([0-9]{4}){4}/" />
+// styles applied: {padding: 10}
+```
+
 #### GlamorousComponent
 
 The `GlamorousComponent` is what is returned from the `glamorousComponentFactory`.

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -232,3 +232,40 @@ exports[`with theme prop of padding 20px 1`] = `
   />
 </glamorous(div)>
 `;
+
+exports[`withProps composes the component with the provided props 1`] = `
+.css-1ezp9xe,
+[data-css-1ezp9xe] {
+  color: red;
+}
+
+<input
+  class="css-1ezp9xe"
+  type="text"
+/>
+`;
+
+exports[`withProps should accept a function producing props 1`] = `
+.css-1ezp9xe,
+[data-css-1ezp9xe] {
+  color: red;
+}
+
+<input
+  class="css-1ezp9xe"
+  pattern="/[0-9]/"
+  type="credit-card"
+/>
+`;
+
+exports[`withProps should have a lower priority than component props 1`] = `
+.css-1ezp9xe,
+[data-css-1ezp9xe] {
+  color: red;
+}
+
+<input
+  class="css-1ezp9xe"
+  type="number"
+/>
+`;

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -433,3 +433,39 @@ test('should accept user defined contextTypes', () => {
   const props = {}
   expect(dynamicStyles).toHaveBeenCalledWith(props, theme, context)
 })
+
+test('withProps composes the component with the provided props', () => {
+  const Input = glamorous.input.withProps({type: 'text'})({color: 'red'})
+  expect(render(<Input />)).toMatchSnapshotWithGlamor()
+})
+
+test('withProps should accept a function producing props', () => {
+  const propsFn = ({validationType}) => {
+    const extraProps = {type: validationType}
+
+    if (validationType === 'credit-card') {
+      extraProps.pattern = /[0-9]/
+    }
+
+    return extraProps
+  }
+  const Input = glamorous.input.withProps(propsFn)({color: 'red'})
+  expect(
+    render(<Input validationType="credit-card" />),
+  ).toMatchSnapshotWithGlamor()
+})
+
+test('withProps is variadic', () => {
+  const propsFn = jest.fn()
+  const propsFn2 = jest.fn()
+
+  const Input = glamorous.input.withProps(propsFn, propsFn2)()
+
+  const wrapper = mount(<Input type="text" pattern="foo" />)
+  expect(propsFn).toHaveBeenCalledWith(wrapper.props())
+})
+
+test('withProps should have a lower priority than component props', () => {
+  const Input = glamorous.input.withProps({type: 'text'})({color: 'red'})
+  expect(render(<Input type="number" />)).toMatchSnapshotWithGlamor()
+})


### PR DESCRIPTION


<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adds `withProps` factory as discussed in #133

<!-- Why are these changes necessary? -->
**Why**: A handy API for composing more than styles on a component 😃 

<!-- How were these changes implemented? -->
**How**: `glamorousComponentFactory` comes with a `withProps` property on it. This allows you to recompose the factory with properties

```js
const GlamorousComponent = glamorous(/* Comp */).withProps({ /* props */ })({ /* styles */ })
```

Note: these properties take a lower priority than properties defined on the `GlamorousComponent` by the user. Just like the styles.

## Feedback Requested

Before finalizing documentation, I'd like to get a sense of the approach is what we'd like!

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Code complete
- [ ] ~~Added myself to contributors table~~ <!-- this is optional, see the contributing guidelines for instructions -->
- [x] Followed the commit message format <!-- this is optional as well, we can fix it for you when we merge your PR, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
