### PR TITLE
feat(typescript): Export all interfaces and types from glamorous.d.ts

### DIFF
--- a/test/glamorous-exports.test.ts
+++ b/test/glamorous-exports.test.ts
@@ -1,0 +1,8 @@
+import {
+  CSSProperties,
+  ExtraGlamorousProps,
+  GlamorousComponent,
+  HTMLGlamorousInterface,
+  StyledFunction,
+  SVGGlamorousInterface,
+} from '../'

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -14,7 +14,14 @@ import {
 } from './styled-function'
 import { CSSProperties } from './css-properties'
 
-export { StyledFunction, ExtraGlamorousProps }
+export {
+  CSSProperties,
+  ExtraGlamorousProps,
+  GlamorousComponent,
+  HTMLGlamorousInterface,
+  StyledFunction,
+  SVGGlamorousInterface,
+}
 
 export interface GlamorousOptions {
   displayName: string


### PR DESCRIPTION
closes #108 

**What**:
Exports all interfaces and types used in `glamorous.d.ts`

**Why**:
They are handy to use in code, in particular I was constructing a styles object before passing it to a glamorous built-in DOM component factory and wanted access to the CSSProperties interface.

**How**:
Exporting all interfaces and types in `glamorous.d.ts` and setting up a test file to ensure all these are available.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Code complete
- [ ] Added myself to contributors table N/A
- [x] Followed the commit message format