### PR TITLE
chore(typescript): Added config to typings

### DIFF
--- a/other/TYPESCRIPT_USAGE.md
+++ b/other/TYPESCRIPT_USAGE.md
@@ -6,6 +6,10 @@ Pull requests to improve them are welcome and appreciated. If you've never contr
 
 ## Complete support
 
+### Config
+
+- [x] useDisplayNameInClassName
+
 ### Dynamic styles
 
 To use dynamic styles with custom props use generics. Example:

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -5,6 +5,9 @@ import glamorous, { withTheme, ThemeProvider } from "../";
 // https://github.com/Microsoft/TypeScript/issues/5938
 import { ExtraGlamorousProps } from "../";
 
+// Glamorous config
+glamorous.config.useDisplayNameInClassName = true
+
 // static styles
 const Static = glamorous.div({
   "fontSize": 20,

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -31,6 +31,10 @@ export interface GlamorousOptions {
 
 export type Component<T> = React.ComponentClass<T> | React.StatelessComponent<T>
 
+export interface Config {
+  useDisplayNameInClassName: boolean
+}
+
 export interface GlamorousInterface extends HTMLGlamorousInterface, SVGGlamorousInterface {
   <P>(
     component:Component<P>,
@@ -39,6 +43,8 @@ export interface GlamorousInterface extends HTMLGlamorousInterface, SVGGlamorous
 
   Div: React.StatelessComponent<CSSProperties & ExtraGlamorousProps>
   Svg: React.StatelessComponent<React.SVGAttributes<any> & ExtraGlamorousProps>
+
+  config: Config
 }
 
 interface ThemeProps {


### PR DESCRIPTION
**What**:

Added missing typing for config, .

**Why**:

We're adding displayNames to aid in development and noticed this type was missing

**How**:

**Checklist**:
- [x] Documentation
- [x] Tests
- [ ] Code complete
- [x] Added myself to contributors table
- [x] Followed the commit message format

<!-- feel free to add additional comments -->

I noticed that the tslint is currently broken against the typescript files.  I'll open a seperate issue for that.  Might be worth using prettier on the types and tests to bring it into line with the core project now prettier has typescript support.  Have opened https://github.com/paypal/glamorous/issues/172 to investigate and resolve.