### PR TITLE
fix(css): improve built-in support with css prop as function

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -80,23 +80,23 @@ exports[`can use pre-built glamorous components with css attributes 1`] = `
 `;
 
 exports[`can use pre-built glamorous components with css prop 1`] = `
-.css-1n96jtr,
-[data-css-1n96jtr] {
+.css-1d3tm0b,
+[data-css-1d3tm0b] {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
-  background: blue;
   display: -webkit-box;
   display: -moz-box;
   display: -ms-flexbox;
   display: -webkit-flex;
   display: flex;
   flex-direction: column;
+  background: blue;
 }
 
 <a
-  class="css-1n96jtr is added to classes"
+  class="css-1d3tm0b is added to classes"
   href="/is-forwarded"
   id="is-forwarded"
 />
@@ -114,13 +114,15 @@ exports[`css prop with a className 1`] = `
 `;
 
 exports[`css prop with a function 1`] = `
-.css-1xnhj1e,
-[data-css-1xnhj1e] {
+.css-1ps4aij,
+[data-css-1ps4aij] {
+  font-size: 10px;
   padding: 20px;
+  margin: 30px;
 }
 
 <section
-  class="css-1xnhj1e"
+  class="css-1ps4aij"
 />
 `;
 

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -73,7 +73,7 @@ exports[`can use pre-built glamorous components with css attributes 1`] = `
 }
 
 <a
-  class="is added to classes css-1t62idy"
+  class="css-1t62idy is added to classes"
   href="/is-forwarded"
   id="is-forwarded"
 />
@@ -96,7 +96,7 @@ exports[`can use pre-built glamorous components with css prop 1`] = `
 }
 
 <a
-  class="is added to classes css-1n96jtr"
+  class="css-1n96jtr is added to classes"
   href="/is-forwarded"
   id="is-forwarded"
 />
@@ -180,7 +180,7 @@ exports[`merges composed component styles for reasonable overrides 1`] = `
 }
 
 <div
-  class="other classes are not removed css-1k8eh41"
+  class="css-1k8eh41 other classes are not removed"
 />
 `;
 

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -78,14 +78,21 @@ test('the css prop accepts "GlamorousStyles"', () => {
     render(<glamorous.Section css={className} />),
   ).toMatchSnapshotWithGlamor('css prop with a className')
 
-  const fn = jest.fn(() => ({padding: 20}))
-  const props = {css: fn, otherThing: 43, theme: {color: 'red'}}
+  const fn1 = jest.fn(() => ({padding: 20}))
+  const fn2 = jest.fn(() => ({margin: 30}))
+  const props = {css: [fn1, fn2], fontSize: 10, theme: {color: 'red'}}
   expect(render(<glamorous.Section {...props} />)).toMatchSnapshotWithGlamor(
     'css prop with a function',
   )
-  expect(fn).toHaveBeenCalledTimes(1)
+  expect(fn1).toHaveBeenCalledTimes(1)
+  expect(fn2).toHaveBeenCalledTimes(1)
   const context = {__glamorous__: undefined}
-  expect(fn).toHaveBeenCalledWith(
+  expect(fn1).toHaveBeenCalledWith(
+    expect.objectContaining(props),
+    expect.objectContaining(props.theme),
+    expect.objectContaining(context),
+  )
+  expect(fn2).toHaveBeenCalledWith(
     expect.objectContaining(props),
     expect.objectContaining(props.theme),
     expect.objectContaining(context),

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -83,7 +83,7 @@ function createGlamorous(splitProps) {
           // readability to get better performance because it actually
           // matters.
           const props = this.props
-          const {toForward, cssOverrides} = splitProps(
+          const {toForward, cssOverrides, cssProp} = splitProps(
             props,
             GlamorousComponent,
           )
@@ -98,6 +98,7 @@ function createGlamorous(splitProps) {
             styles: GlamorousComponent.styles,
             props,
             cssOverrides,
+            cssProp,
             theme,
             context: this.context,
           })

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -94,13 +94,13 @@ function createGlamorous(splitProps) {
             Object.freeze(this.state.theme)
 
           // create className to apply
-          const fullClassName = getGlamorClassName(
-            GlamorousComponent.styles,
+          const fullClassName = getGlamorClassName({
+            styles: GlamorousComponent.styles,
             props,
             cssOverrides,
             theme,
-            this.context,
-          )
+            context: this.context,
+          })
           const debugClassName = glamorous.config.useDisplayNameInClassName ?
             cleanClassname(GlamorousComponent.displayName) :
             ''

--- a/src/get-glamor-classname.js
+++ b/src/get-glamor-classname.js
@@ -25,29 +25,20 @@ function extractGlamorStyles(className = '') {
 
 export default getGlamorClassName
 
-function getGlamorClassName(styles, props, cssOverrides, theme, context) {
-  const {mappedArgs, nonGlamorClassNames} = handleStyles(
-    styles,
-    props,
-    theme,
-    context,
-  )
-  const {
-    mappedArgs: cssOverridesArgs,
-    nonGlamorClassNames: cssOverridesClassNames,
-  } = handleStyles([cssOverrides], props, theme, context)
+function getGlamorClassName({styles, props, cssOverrides, theme, context}) {
   const {
     glamorStyles: parentGlamorStyles,
     glamorlessClassName,
   } = extractGlamorStyles(props.className)
-
-  const glamorClassName = css(
-    ...mappedArgs,
-    ...parentGlamorStyles,
-    ...cssOverridesArgs,
-  ).toString()
-  const extras = nonGlamorClassNames.concat(cssOverridesClassNames).join(' ')
-  return `${glamorlessClassName} ${glamorClassName} ${extras}`.trim()
+  const {mappedArgs, nonGlamorClassNames} = handleStyles(
+    [...styles, parentGlamorStyles, cssOverrides],
+    props,
+    theme,
+    context,
+  )
+  const glamorClassName = css(...mappedArgs).toString()
+  const extras = [...nonGlamorClassNames, glamorlessClassName].join(' ').trim()
+  return `${glamorClassName} ${extras}`.trim()
 }
 
 function handleStyles(styles, props, theme, context) {

--- a/src/split-props.js
+++ b/src/split-props.js
@@ -2,7 +2,7 @@ import shouldForwardProperty from './should-forward-property'
 
 export default function splitProps(
   {
-    css: cssOverrides = {},
+    css: cssProp,
     // these are plucked off
     theme, // because they
     className, // should never
@@ -13,7 +13,7 @@ export default function splitProps(
   },
   {propsAreCssOverrides, rootEl, forwardProps},
 ) {
-  const returnValue = {toForward: {}, cssOverrides}
+  const returnValue = {toForward: {}, cssProp, cssOverrides: {}}
   if (!propsAreCssOverrides) {
     if (typeof rootEl !== 'string') {
       // if it's not a string, then we can forward everything

--- a/src/tiny.js
+++ b/src/tiny.js
@@ -2,7 +2,7 @@
 import createGlamorous from './create-glamorous'
 
 function splitProps({
-  css: cssOverrides = {},
+  css: cssProp,
   // these are plucked off
   theme, // because they
   className, // should never
@@ -11,7 +11,7 @@ function splitProps({
   // component ever
   ...rest
 }) {
-  return {toForward: rest, cssOverrides}
+  return {toForward: rest, cssProp}
 }
 
 const glamorous = createGlamorous(splitProps)


### PR DESCRIPTION
I'm working on fixing a bug I found while making [this](https://codesandbox.io/s/ERNVNoxEv) (notice that the `textAlign="center"` is not applied to the first user card because the `css` prop is set to a function.

As part of making that an easier fix, I'm refactoring `getGlamorClassName` and I'm not sure why a bunch of the tests are breaking. I've only dug a little ways into it, but now I've got daddy duty. If anyone wants to debug it and figure out what's up, that'd be awesome. At first glance, it appears that the class names are generated properly, but somehow they're not added to glamor's stylesheet which is why they're not appearing in the snapshot???? Weird stuff.