### PR TITLE
chore(theme): swap custom theme code with `withTheme`

### DIFF
--- a/dist-test/index.js
+++ b/dist-test/index.js
@@ -129,7 +129,7 @@ function hasNamedExports(thing) {
   return keys.every(
     key =>
       typeof thing[key] === GlamorousComponents[key] &&
-      thing[key].name === 'GlamorousComponent',
+      thing[key].isGlamorousComponent,
   )
 }
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
     ],
     "rules": {
       "import/prefer-default-export": 0,
-      "react/no-unused-prop-types": 0
+      "react/no-unused-prop-types": 0,
+      "valid-jsdoc": 0
     }
   },
   "lint-staged": {

--- a/src/__tests__/with-theme.js
+++ b/src/__tests__/with-theme.js
@@ -96,7 +96,7 @@ test('pass through when no theme provider found up tree', () => {
   expect(console.warn).toHaveBeenCalledTimes(1)
   expect(console.warn).toHaveBeenCalledWith(
     // eslint-disable-next-line max-len
-    `glamorous warning: Expected component called "Stateless Function" which uses withTheme to be within a ThemeProvider but none was found.`,
+    `glamorous warning: Expected component called "FunctionComponent" which uses withTheme to be within a ThemeProvider but none was found.`,
   )
   console.warn = originalWarn
 })
@@ -128,4 +128,13 @@ test('unsubscribes from theme updates on unmount', () => {
   })
   wrapper.unmount()
   expect(unsubscribe).toHaveBeenCalled()
+})
+
+test('ignores context if a theme props is passed', () => {
+  const unsubscribe = jest.fn()
+  const context = getMockedContext(unsubscribe)
+  const Comp = withTheme(() => <div />)
+  const wrapper = mount(<Comp theme={{}} />, {context})
+  wrapper.unmount()
+  expect(unsubscribe).toHaveBeenCalledTimes(0)
 })

--- a/src/with-theme.js
+++ b/src/with-theme.js
@@ -3,37 +3,52 @@ import React, {Component} from 'react'
 import {CHANNEL} from './constants'
 import {PropTypes} from './react-compat'
 
-function generateWarningMessage(componentName) {
+function generateWarningMessage(Comp) {
+  const componentName = Comp.displayName || Comp.name || 'FunctionComponent'
   // eslint-disable-next-line max-len
   return `glamorous warning: Expected component called "${componentName}" which uses withTheme to be within a ThemeProvider but none was found.`
 }
 
-export default function withTheme(ComponentToTheme) {
+export default function withTheme(
+  ComponentToTheme,
+  {noWarn = false, createElement = true} = {},
+) {
   class ThemedComponent extends Component {
+    static propTypes = {
+      theme: PropTypes.object,
+    }
+    warned = noWarn
     state = {theme: {}}
     setTheme = theme => this.setState({theme})
 
+    // eslint-disable-next-line complexity
     componentWillMount() {
       if (!this.context[CHANNEL]) {
-        if (process.env.NODE_ENV !== 'production') {
+        if (process.env.NODE_ENV !== 'production' && !this.warned) {
+          this.warned = true
           // eslint-disable-next-line no-console
-          console.warn(
-            generateWarningMessage(
-              ComponentToTheme.displayName ||
-                ComponentToTheme.name ||
-                'Stateless Function',
-            ),
-          )
+          console.warn(generateWarningMessage(ComponentToTheme))
         }
-
-        return
       }
+      const {theme} = this.props
+      if (this.context[CHANNEL]) {
+        // if a theme is provided via props,
+        // it takes precedence over context
+        this.setTheme(theme ? theme : this.context[CHANNEL].getState())
+      } else {
+        this.setTheme(theme || {})
+      }
+    }
 
-      this.setState({theme: this.context[CHANNEL].getState()})
+    componentWillReceiveProps(nextProps) {
+      if (this.props.theme !== nextProps.theme) {
+        this.setTheme(nextProps.theme)
+      }
     }
 
     componentDidMount() {
-      if (this.context[CHANNEL]) {
+      if (this.context[CHANNEL] && !this.props.theme) {
+        // subscribe to future theme changes
         this.unsubscribe = this.context[CHANNEL].subscribe(this.setTheme)
       }
     }
@@ -44,13 +59,45 @@ export default function withTheme(ComponentToTheme) {
     }
 
     render() {
-      return <ComponentToTheme {...this.props} {...this.state} />
+      if (createElement) {
+        return <ComponentToTheme {...this.props} {...this.state} />
+      } else {
+        // this allows us to effectively use the GlamorousComponent
+        // as our `render` method without going through lifecycle hooks.
+        // Also allows us to forward the context in the scenario where
+        // a user wants to add more context.
+        // eslint-disable-next-line babel/new-cap
+        return ComponentToTheme({...this.props, ...this.state}, this.context)
+      }
     }
   }
 
-  ThemedComponent.contextTypes = {
+  const defaultContextTypes = {
     [CHANNEL]: PropTypes.object,
   }
+
+  let userDefinedContextTypes = null
+
+  // configure the contextTypes to be settable by the user,
+  // however also retaining the glamorous channel.
+  Object.defineProperty(ThemedComponent, 'contextTypes', {
+    enumerable: true,
+    configurable: true,
+    set(value) {
+      userDefinedContextTypes = value
+    },
+    get() {
+      // if the user has provided a contextTypes definition,
+      // merge the default context types with the provided ones.
+      if (userDefinedContextTypes) {
+        return {
+          ...defaultContextTypes,
+          ...userDefinedContextTypes,
+        }
+      }
+      return defaultContextTypes
+    },
+  })
 
   return ThemedComponent
 }


### PR DESCRIPTION
**What**: This changes the GlamorousComponent from a class to a function that uses `withTheme`.

**Why**: This simplifies the codebase and prepares us for potentially dropping our own theming implementation in favor of the `theming` module.

**How**: Refactoring `withTheme` to have all the features that the glamorous component had and wrapping the glamorous component in `withTheme`.

This change _should_ be totally non-breaking despite some of the test changes. I'd really appreciate a review on this one from folks.