### PR TITLE
fix: remove useDisplayNameInClassName and use glamor's built-in `label`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@
   - [glamorous](#glamorous)
   - [glamorous API](#glamorous-api)
   - [Theming](#theming)
-  - [Config](#config)
   - [Context](#context)
   - [Size](#size)
   - [Server Side Rendering (SSR)](#server-side-rendering-ssr)
@@ -249,7 +248,7 @@ const MyStyledComp = glamorous(UnstyledComp)({ margin: 1 })
 
 <MyStyledComp>content</MyStyledComp>
 // rendered output: <div class="<glamor-generated-class> other-class">content</div>
-// styles applied: 
+// styles applied:
 // <glamor-generated-class> {
 //  margin: 1px;
 // }
@@ -761,40 +760,6 @@ class SubTitle extends Component {
 </ThemeProvider>
 ```
 > `withTheme` expects a `ThemeProvider` further up the render tree and will warn in `development` if one is not found!
-
-### Config
-
-You can configure glamorous globally with the `config` object which you can
-access via `glamorous.config`.
-
-#### useDisplayNameInClassName
-
-Defaults to process.env.NODE_ENV !== 'test'
-This should _only_ be used for debugging purposes. It is strongly discouraged
-from referencing this className in your CSS due to the level of indirection that
-will add (making it easier for you to break something when refactoring in the
-future).
-
-Example:
-
-```jsx
-import glamorous from 'glamorous'
-glamorous.config.useDisplayNameInClassName = true
-
-const MyComponent = props => <div {...props} />
-const myGlamorousComponentFactory = glamorous(
-  MyComponent,
-  {displayName: 'MyGlamorousComponent'}
-)
-
-const MyGlamorousComponent = myGlamorousComponentFactory()
-<MyGlamorousComponent />
-// renders <div class="css-nil MyGlamorousComponent" />
-```
-
-If you don't want to provide the `displayName` for all of your components, then
-you can use [this babel-plugin][babel-displayname]. Otherwise, the className
-will be simply: `glamorous(MyComponent)`
 
 ### Context
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,3 +6,13 @@
 ### How about source mapping in dev tools?
 
 Glamorous is based on glamor which does not support source map. This is unfortunate. However you can generally figure out what component is responsible for what you're looking at easily, especially with the [babel plugin](https://www.npmjs.com/package/babel-plugin-glamorous-displayname) (https://github.com/paypal/glamorous#usedisplaynameinclassname).
+
+### How does semver work here?
+
+Glamorous follows semver with regards to official APIs and type definitions.
+If a change needs to be made with regards to how glamorous generates the
+classNames, that will be made as a patch or minor release rather than a major
+release (as you should not be relying on the generated classNames anyway).
+If you're concerned about your Jest snapshots breaking due to changes in
+the className, you should use [`jest-glamor-react`](https://github.com/kentcdodds/jest-glamor-react) which
+will not be impacted by changes to the className.

--- a/examples/with-jest/index.test.js
+++ b/examples/with-jest/index.test.js
@@ -10,7 +10,7 @@ test('enzyme', () => {
     </Wrapper>
   )
 
-  expect(shallow(ui)).toMatchSnapshotWithGlamor(`enzyme.shallow`)
-  expect(mount(ui)).toMatchSnapshotWithGlamor(`enzyme.mount`)
-  expect(render(ui)).toMatchSnapshotWithGlamor(`enzyme.render`)
+  expect(shallow(ui)).toMatchSnapshot(`enzyme.shallow`)
+  expect(mount(ui)).toMatchSnapshot(`enzyme.mount`)
+  expect(render(ui)).toMatchSnapshot(`enzyme.render`)
 })

--- a/examples/with-jest/testSetup.js
+++ b/examples/with-jest/testSetup.js
@@ -3,5 +3,5 @@ import {matcher, serializer} from 'jest-glamor-react'
 // This is what adds the CSS to the output snapshot
 expect.addSnapshotSerializer(serializer)
 
-// this adds toMatchSnapshotWithGlamor to expect and makes the snapshot diff output look nice in the terminal
+// this adds toMatchSnapshot to expect and makes the snapshot diff output look nice in the terminal
 expect.extend(matcher)

--- a/package.json
+++ b/package.json
@@ -53,10 +53,10 @@
     "enzyme-to-json": "^1.5.1",
     "eslint": "^4.3.0",
     "eslint-config-kentcdodds": "^12.4.2",
-    "glamor": "^2.20.31",
+    "glamor": "^2.20.37",
     "husky": "^0.14.3",
     "jest-cli": "^20.0.4",
-    "jest-glamor-react": "^2.0.0",
+    "jest-glamor-react": "^3.0.0",
     "lint-staged": "^4.0.2",
     "nps": "^5.3.1",
     "nps-utils": "^1.1.2",
@@ -107,7 +107,7 @@
         "statements": 100
       }
     },
-    "snapshotSerializers": ["enzyme-to-json/serializer"],
+    "snapshotSerializers": ["enzyme-to-json/serializer", "jest-glamor-react"],
     "roots": ["src"]
   },
   "repository": {

--- a/src/__tests__/__snapshots__/dev.js.snap
+++ b/src/__tests__/__snapshots__/dev.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can be configured to use the displayName in the className 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  color: red;
+}
+
+<div
+  class="glamor-0"
+/>
+`;

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -51,12 +51,6 @@ exports[`can accept functions which return string class names 1`] = `
 />
 `;
 
-exports[`can be configured to use the displayName in the className 1`] = `
-<div
-  class="css-nil Hi-There"
-/>
-`;
-
 exports[`can use pre-built glamorous components with css attributes 1`] = `
 .glamor-0,
 [data-glamor-0] {
@@ -164,7 +158,7 @@ exports[`forwards props when the GlamorousComponent.rootEl is known 1`] = `
 
 exports[`merges composed component forwardProps 1`] = `
 <div
-  class="css-nil"
+  class="css-1268me8"
 />
 `;
 
@@ -235,7 +229,7 @@ exports[`styles can be functions that accept props 1`] = `
 
 exports[`will forward \`color\` to an svg 1`] = `
 <svg
-  class="css-nil"
+  class="css-1268me8"
   color="red"
 />
 `;

--- a/src/__tests__/create-glamorous.with-component.js
+++ b/src/__tests__/create-glamorous.with-component.js
@@ -1,17 +1,13 @@
 /* eslint func-style:0, react/prop-types:0 */
 import React from 'react'
 import {render} from 'enzyme'
-import * as jestGlamorReact from 'jest-glamor-react'
 import * as glamor from 'glamor'
 import glamorous from '../'
-
-expect.extend(jestGlamorReact.matcher)
-expect.addSnapshotSerializer(jestGlamorReact.serializer)
 
 test('withComponent composes the component with provided styles', () => {
   const Text = glamorous.span({color: 'red', fontSize: 20})
   const View = Text.withComponent('div')
-  expect(render(<View />)).toMatchSnapshotWithGlamor()
+  expect(render(<View />)).toMatchSnapshot()
 })
 
 test('withComponent creates a new component with the provided tag', () => {
@@ -51,13 +47,13 @@ test('resulting component can have its styles extended further', () => {
   const Text = glamorous.span({color: 'red', fontSize: 20})
   const View = Text.withComponent('div')
   const StyledView = glamorous(View)({color: 'blue'})
-  expect(render(<StyledView />)).toMatchSnapshotWithGlamor(
+  expect(render(<StyledView />)).toMatchSnapshot(
     'overriding styles via wrapping with glamorous',
   )
-  expect(render(<View css={{fontSize: 25}} />)).toMatchSnapshotWithGlamor(
+  expect(render(<View css={{fontSize: 25}} />)).toMatchSnapshot(
     'overriding styles via css prop',
   )
   expect(
     render(<View className={glamor.css({color: 'green'}).toString()} />),
-  ).toMatchSnapshotWithGlamor('overriding styles via className')
+  ).toMatchSnapshot('overriding styles via className')
 })

--- a/src/__tests__/dev.js
+++ b/src/__tests__/dev.js
@@ -1,0 +1,32 @@
+/*
+ * This file is here to test things that glamor does when
+ * NODE_ENV === 'development'
+ *
+ * Because glamor stores the value in the module level of
+ * it's implementation files, we have to do some funny things
+ * to make sure that glamor gets the value we want.
+ */
+import React from 'react'
+import {render} from 'enzyme'
+
+const nodeEnv = process.env.NODE_ENV
+
+beforeEach(() => {
+  process.env.NODE_ENV = 'development'
+  jest.resetModules()
+})
+
+afterEach(() => {
+  process.env.NODE_ENV = nodeEnv
+})
+
+test('can be configured to use the displayName in the className', () => {
+  // eslint-disable-next-line
+  const glamorous = require('../').default
+  const MyComp = glamorous(props => <div {...props} />, {
+    displayName: 'Hi There',
+  })({color: 'red'})
+  const wrapper = render(<MyComp />)
+  expect(wrapper).toMatchSnapshot()
+  expect(wrapper.html()).toMatch(/hi-there/)
+})

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -2,14 +2,10 @@
 import React from 'react'
 import * as glamor from 'glamor'
 import {render, mount} from 'enzyme'
-import * as jestGlamorReact from 'jest-glamor-react'
 import {oneLine} from 'common-tags'
 import glamorous, {ThemeProvider} from '../'
 import {PropTypes} from '../react-compat'
 import {CHANNEL} from '../constants'
-
-expect.extend(jestGlamorReact.matcher)
-expect.addSnapshotSerializer(jestGlamorReact.serializer)
 
 const nodeEnv = process.env.NODE_ENV
 
@@ -19,7 +15,7 @@ afterEach(() => {
 
 test('sanity test', () => {
   const Div = glamorous.div({marginLeft: 24})
-  expect(render(<Div />)).toMatchSnapshotWithGlamor()
+  expect(render(<Div />)).toMatchSnapshot()
 })
 
 test('can use pre-built glamorous components with css attributes', () => {
@@ -33,7 +29,7 @@ test('can use pre-built glamorous components with css attributes', () => {
         className="is added to classes"
       />,
     ),
-  ).toMatchSnapshotWithGlamor()
+  ).toMatchSnapshot()
 })
 
 test('can use pre-built glamorous components with css prop', () => {
@@ -51,12 +47,12 @@ test('can use pre-built glamorous components with css prop', () => {
         }}
       />,
     ),
-  ).toMatchSnapshotWithGlamor()
+  ).toMatchSnapshot()
 })
 
 test('the css prop accepts "GlamorousStyles"', () => {
   const object = {fontSize: 12}
-  expect(render(<glamorous.Section css={object} />)).toMatchSnapshotWithGlamor(
+  expect(render(<glamorous.Section css={object} />)).toMatchSnapshot(
     'css prop with an object',
   )
 
@@ -64,21 +60,21 @@ test('the css prop accepts "GlamorousStyles"', () => {
     {marginTop: 1, marginRight: 1},
     {marginRight: 2, marginBottom: 2},
   ]
-  expect(render(<glamorous.Section css={array} />)).toMatchSnapshotWithGlamor(
+  expect(render(<glamorous.Section css={array} />)).toMatchSnapshot(
     'css prop with an array',
   )
 
   // this one's weird, but could enable some Ahead of Time
   // compilation in the future
   const className = `${glamor.css({color: 'red'})} abc-123`
-  expect(
-    render(<glamorous.Section css={className} />),
-  ).toMatchSnapshotWithGlamor('css prop with a className')
+  expect(render(<glamorous.Section css={className} />)).toMatchSnapshot(
+    'css prop with a className',
+  )
 
   const fn1 = jest.fn(() => ({padding: 20}))
   const fn2 = jest.fn(() => ({margin: 30}))
   const props = {css: [fn1, fn2], fontSize: 10, theme: {color: 'red'}}
-  expect(render(<glamorous.Section {...props} />)).toMatchSnapshotWithGlamor(
+  expect(render(<glamorous.Section {...props} />)).toMatchSnapshot(
     'css prop with a function',
   )
   expect(fn1).toHaveBeenCalledTimes(1)
@@ -140,7 +136,7 @@ test('merges composed component styles for reasonable overrides', () => {
     expect(el.attribs.class).toContain(className)
   })
   // still using a snapshot though for good measure
-  expect(wrapper).toMatchSnapshotWithGlamor()
+  expect(wrapper).toMatchSnapshot()
 })
 
 test('merges composed component forwardProps', () => {
@@ -150,14 +146,14 @@ test('merges composed component forwardProps', () => {
   const Child = glamorous(parent, {forwardProps: ['shouldRender']})()
   const Grandchild = glamorous(Child)()
   const wrapper = render(<Grandchild shouldRender={true} />)
-  expect(wrapper).toMatchSnapshotWithGlamor()
+  expect(wrapper).toMatchSnapshot()
 })
 
 test('styles can be functions that accept props', () => {
   const MyDiv = glamorous.div({marginTop: 1}, ({margin}) => ({
     marginTop: margin,
   }))
-  expect(render(<MyDiv margin={2} />)).toMatchSnapshotWithGlamor()
+  expect(render(<MyDiv margin={2} />)).toMatchSnapshot()
 })
 
 test('style objects can be arrays and glamor will merge those', () => {
@@ -176,9 +172,7 @@ test('style objects can be arrays and glamor will merge those', () => {
       return [bigStyles, squareStyles]
     },
   )
-  expect(
-    render(<MyDiv big={true} square={false} />),
-  ).toMatchSnapshotWithGlamor()
+  expect(render(<MyDiv big={true} square={false} />)).toMatchSnapshot()
 })
 
 test('falls back to `name` if displayName cannot be inferred', () => {
@@ -199,22 +193,12 @@ test('allows you to specify a displayName', () => {
   expect(MyComp.displayName).toBe('Hi There')
 })
 
-test('can be configured to use the displayName in the className', () => {
-  const original = glamorous.config.useDisplayNameInClassName
-  glamorous.config.useDisplayNameInClassName = true
-  const MyComp = glamorous(props => <div {...props} />, {
-    displayName: 'Hi There',
-  })()
-  expect(render(<MyComp />)).toMatchSnapshotWithGlamor()
-  glamorous.config.useDisplayNameInClassName = original
-})
-
 test('will not forward `color` to a div', () => {
-  expect(render(<glamorous.Div color="red" />)).toMatchSnapshotWithGlamor()
+  expect(render(<glamorous.Div color="red" />)).toMatchSnapshot()
 })
 
 test('will forward `color` to an svg', () => {
-  expect(render(<glamorous.Svg color="red" />)).toMatchSnapshotWithGlamor()
+  expect(render(<glamorous.Svg color="red" />)).toMatchSnapshot()
 })
 
 test('allows you to specify the tag rendered by a component', () => {
@@ -227,7 +211,7 @@ test('allows you to specify the tag rendered by a component', () => {
     render(
       <MyStyledSvgComponent height={2} noForward={true} css={{width: 2}} />,
     ),
-  ).toMatchSnapshotWithGlamor()
+  ).toMatchSnapshot()
 })
 
 test('forwards props when the GlamorousComponent.rootEl is known', () => {
@@ -296,7 +280,7 @@ test('forwards props when the GlamorousComponent.rootEl is known', () => {
     expect.anything(),
     expect.anything(),
   )
-  expect(ui).toMatchSnapshotWithGlamor()
+  expect(ui).toMatchSnapshot()
 })
 
 test('renders a component with theme properties', () => {
@@ -306,9 +290,7 @@ test('renders a component with theme properties', () => {
     },
     ({theme}) => ({padding: theme.padding}),
   )
-  expect(
-    render(<Comp theme={{padding: '10px'}} />),
-  ).toMatchSnapshotWithGlamor()
+  expect(render(<Comp theme={{padding: '10px'}} />)).toMatchSnapshot()
 })
 
 test('passes an updated theme when theme prop changes', () => {
@@ -319,9 +301,9 @@ test('passes an updated theme when theme prop changes', () => {
     ({theme}) => ({padding: theme.padding}),
   )
   const wrapper = mount(<Comp theme={{padding: 10}} />)
-  expect(wrapper).toMatchSnapshotWithGlamor(`with theme prop of padding 10px`)
+  expect(wrapper).toMatchSnapshot(`with theme prop of padding 10px`)
   wrapper.setProps({theme: {padding: 20}})
-  expect(wrapper).toMatchSnapshotWithGlamor(`with theme prop of padding 20px`)
+  expect(wrapper).toMatchSnapshot(`with theme prop of padding 20px`)
 })
 
 test('passes `theme` to the css prop if it is a function', () => {
@@ -353,7 +335,7 @@ test('allows you to pass custom props that are allowed', () => {
     render(
       <MyStyledComponent shouldRender={true} otherThing={false} id="hello" />,
     ),
-  ).toMatchSnapshotWithGlamor()
+  ).toMatchSnapshot()
   expect(MyComponent).toHaveBeenCalledTimes(1)
   expect(MyComponent).toHaveBeenCalledWith(
     {
@@ -392,14 +374,14 @@ test('can accept classNames instead of style objects', () => {
     styles4,
     'extra-thing',
   )
-  expect(render(<Comp />)).toMatchSnapshotWithGlamor()
+  expect(render(<Comp />)).toMatchSnapshot()
 })
 
 test('can accept functions which return string class names', () => {
   const styles1 = {paddingRight: 2, paddingBottom: 2}
   const styles2 = props => (props.active ? 'is-active' : '')
   const Comp = glamorous.div(styles1, styles2, 'extra-thing')
-  expect(render(<Comp active />)).toMatchSnapshotWithGlamor()
+  expect(render(<Comp active />)).toMatchSnapshot()
 })
 
 test('should accept user defined contextTypes', () => {

--- a/src/__tests__/theme-provider.js
+++ b/src/__tests__/theme-provider.js
@@ -1,13 +1,9 @@
 /* eslint func-style:0 */
 import React, {Component} from 'react'
 import {render, mount} from 'enzyme'
-import * as jestGlamorReact from 'jest-glamor-react'
 import glamorous from '../'
 import ThemeProvider from '../theme-provider'
 import {CHANNEL} from '../constants'
-
-expect.extend(jestGlamorReact.matcher)
-expect.addSnapshotSerializer(jestGlamorReact.serializer)
 
 const getMockedContext = unsubscribe => ({
   [CHANNEL]: {
@@ -30,7 +26,7 @@ test('renders a component with theme', () => {
         <Comp />
       </ThemeProvider>,
     ),
-  ).toMatchSnapshotWithGlamor()
+  ).toMatchSnapshot()
 })
 
 test('theme properties updates get propagated down the tree', () => {
@@ -54,9 +50,9 @@ test('theme properties updates get propagated down the tree', () => {
     ({theme}) => ({padding: theme.padding}),
   )
   const wrapper = mount(<Parent />)
-  expect(wrapper).toMatchSnapshotWithGlamor(`with theme prop of padding 10px`)
+  expect(wrapper).toMatchSnapshot(`with theme prop of padding 10px`)
   wrapper.setState({padding: 20})
-  expect(wrapper).toMatchSnapshotWithGlamor(`with theme prop of padding 20px`)
+  expect(wrapper).toMatchSnapshot(`with theme prop of padding 20px`)
 })
 
 test('merges nested themes', () => {
@@ -81,7 +77,7 @@ test('merges nested themes', () => {
         </ThemeProvider>
       </div>,
     ),
-  ).toMatchSnapshotWithGlamor()
+  ).toMatchSnapshot()
 })
 
 test('renders if children are null', () => {
@@ -91,7 +87,7 @@ test('renders if children are null', () => {
         {false && <div />}
       </ThemeProvider>,
     ),
-  ).toMatchSnapshotWithGlamor()
+  ).toMatchSnapshot()
 })
 
 test('cleans up outer theme subscription when unmounts', () => {
@@ -105,7 +101,7 @@ test('cleans up outer theme subscription when unmounts', () => {
 test('does nothing when receive same theme via props', () => {
   const theme = {margin: 2}
   const wrapper = mount(<ThemeProvider theme={theme} />)
-  expect(wrapper).toMatchSnapshotWithGlamor(`with theme prop of margin 2px`)
+  expect(wrapper).toMatchSnapshot(`with theme prop of margin 2px`)
   wrapper.setProps({theme})
-  expect(wrapper).toMatchSnapshotWithGlamor(`with theme prop of margin 2px`)
+  expect(wrapper).toMatchSnapshot(`with theme prop of margin 2px`)
 })

--- a/src/__tests__/tiny.js
+++ b/src/__tests__/tiny.js
@@ -1,12 +1,8 @@
 /* eslint func-style:0, react/prop-types:0 */
 import React from 'react'
 import {render} from 'enzyme'
-import * as jestGlamorReact from 'jest-glamor-react'
 
 import glamorousTiny from '../tiny'
-
-expect.extend(jestGlamorReact.matcher)
-expect.addSnapshotSerializer(jestGlamorReact.serializer)
 
 test('should pass glam object prop', () => {
   const dynamicStyles = jest.fn(({glam: {big}}) => ({
@@ -23,7 +19,7 @@ test('should pass glam object prop', () => {
   const theme = {color: 'blue'}
   expect(
     render(<Comp id="hey-there" glam={glam} theme={theme} />),
-  ).toMatchSnapshotWithGlamor()
+  ).toMatchSnapshot()
   expect(dynamicStyles).toHaveBeenCalledTimes(1)
   const props = {
     glam,

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -10,9 +10,6 @@ import getGlamorClassName from './get-glamor-classname'
 export default createGlamorous
 
 function createGlamorous(splitProps) {
-  glamorous.config = {
-    useDisplayNameInClassName: process.env.NODE_ENV !== 'test',
-  }
   return glamorous
 
   /**
@@ -52,17 +49,14 @@ function createGlamorous(splitProps) {
           )
 
           // create className to apply
-          const fullClassName = getGlamorClassName({
+          const className = getGlamorClassName({
             styles: GlamorousComponent.styles,
             props,
             cssOverrides,
             cssProp,
             context,
+            displayName: GlamorousComponent.displayName,
           })
-          const debugClassName = glamorous.config.useDisplayNameInClassName ?
-            cleanClassname(GlamorousComponent.displayName) :
-            ''
-          const className = `${fullClassName} ${debugClassName}`.trim()
 
           return React.createElement(GlamorousComponent.comp, {
             ref: props.innerRef,
@@ -136,8 +130,4 @@ function createGlamorous(splitProps) {
       comp :
       comp.displayName || comp.name || 'unknown'
   }
-}
-
-function cleanClassname(className) {
-  return className.replace(/ /g, '-').replace(/[^A-Za-z0-9\-_]/g, '_')
 }

--- a/src/get-glamor-classname.js
+++ b/src/get-glamor-classname.js
@@ -25,7 +25,14 @@ function extractGlamorStyles(className = '') {
 
 export default getGlamorClassName
 
-function getGlamorClassName({styles, props, cssOverrides, cssProp, context}) {
+function getGlamorClassName({
+  styles,
+  props,
+  cssOverrides,
+  cssProp,
+  context,
+  displayName,
+}) {
   const {
     glamorStyles: parentGlamorStyles,
     glamorlessClassName,
@@ -35,7 +42,7 @@ function getGlamorClassName({styles, props, cssOverrides, cssProp, context}) {
     props,
     context,
   )
-  const glamorClassName = css(...mappedArgs).toString()
+  const glamorClassName = css({label: displayName}, ...mappedArgs).toString()
   const extras = [...nonGlamorClassNames, glamorlessClassName].join(' ').trim()
   return `${glamorClassName} ${extras}`.trim()
 }


### PR DESCRIPTION
closes #242

BREAKING CHANGE: It is no longer possible to configure anything with glamorous

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: remove useDisplayNameInClassName and use glamor's built-in `label` instead

<!-- Why are these changes necessary? -->
**Why**: it's better

<!-- How were these changes implemented? -->
**How**:
- Removed docs for config
- added a `dev.js` to test this feature
- accept `displayName` in `getGlamorClassName` and add a `{label: displayName}` for every call to glamor's `css` function.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
