### PR TITLE
task(typescript): remove useDisplayNameInClassName and config

### DIFF
--- a/other/TYPESCRIPT_USAGE.md
+++ b/other/TYPESCRIPT_USAGE.md
@@ -6,10 +6,6 @@ Pull requests to improve them are welcome and appreciated. If you've never contr
 
 ## Complete support
 
-### Config
-
-- [x] useDisplayNameInClassName
-
 ### glamorousComponentFactory
 
 The typings for

--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Typescript expected failures 1`] = `
-"test/glamorous.test.tsx(175,31): error TS2322: Type 'HTMLDivElement | null' is not assignable to type 'HTMLDivElement'.
+"test/glamorous.test.tsx(172,31): error TS2322: Type 'HTMLDivElement | null' is not assignable to type 'HTMLDivElement'.
   Type 'null' is not assignable to type 'HTMLDivElement'.
 test/should-fail.test.tsx(10,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
   Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}, object>)[]'.
@@ -46,5 +46,9 @@ test/should-fail.test.tsx(112,3): error TS2344: Type 'ThemeProps' does not satis
 test/should-fail.test.tsx(121,7): error TS2451: Cannot redeclare block-scoped variable 'NonGlamorousThemedComponent'.
 test/should-fail.test.tsx(122,3): error TS2344: Type 'PropsWithoutTheme' does not satisfy the constraint '{ theme: any; }'.
   Property 'theme' is missing in type 'PropsWithoutTheme'.
+test/should-fail.test.tsx(131,3): error TS2345: Argument of type '{ displayName: number; }' is not assignable to parameter of type 'Partial<GlamorousOptions> | undefined'.
+  Type '{ displayName: number; }' is not assignable to type 'Partial<GlamorousOptions>'.
+    Types of property 'displayName' are incompatible.
+      Type 'number' is not assignable to type 'string | undefined'.
 "
 `;

--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Typescript expected failures 1`] = `
-"test/glamorous.test.tsx(172,31): error TS2322: Type 'HTMLDivElement | null' is not assignable to type 'HTMLDivElement'.
-  Type 'null' is not assignable to type 'HTMLDivElement'.
-test/should-fail.test.tsx(10,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
+"test/should-fail.test.tsx(10,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
   Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}, object>)[]'.
     Property 'length' is missing in type '{ fillRule: \\"cat\\"; }'.
 test/should-fail.test.tsx(16,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -169,7 +169,7 @@ export class AirBalloon extends React.Component<{}, {}> {
 class Test extends React.Component<object, object> {
   private div: HTMLDivElement
   render() {
-    return <div ref={(c) => { this.div = c }} />
+    return <div ref={(c: HTMLDivElement) => { this.div = c }} />
   }
 }
 

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -7,9 +7,6 @@ import { ExtraGlamorousProps } from "../";
 
 import { WithComponent } from "../"
 
-// Glamorous config
-glamorous.config.useDisplayNameInClassName = true
-
 // Partial<Properties>
 const Static = glamorous.div({
   "fontSize": 20,
@@ -268,4 +265,15 @@ const UseNonGlamorousThemedComponent = (
       title='test'
     />
   </div>
+)
+
+// displayName
+
+const TestDisplayName: React.SFC<object> = () => <div />
+
+glamorous(
+  TestDisplayName,
+  {
+    displayName: 'example'
+  },
 )

--- a/test/should-fail.test.tsx
+++ b/test/should-fail.test.tsx
@@ -122,3 +122,13 @@ const NonGlamorousThemedComponent = withTheme<
   PropsWithoutTheme
 >(ComponentWithTheme)
 
+// displayName
+
+const TestDisplayName: React.SFC<object> = () => <div />
+
+glamorous(
+  TestDisplayName,
+  {
+    displayName: 0
+  },
+)

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -48,10 +48,6 @@ export interface GlamorousOptions {
 
 export type Component<T> = React.ComponentClass<T> | React.StatelessComponent<T>
 
-export interface Config {
-  useDisplayNameInClassName: boolean
-}
-
 
 type OmitInternals<
   Props extends { className?: string, theme?: object }
@@ -71,8 +67,6 @@ export interface GlamorousInterface extends HTMLComponentFactory, SVGComponentFa
 
   Div: React.StatelessComponent<CSSProperties & ExtraGlamorousProps>
   Svg: React.StatelessComponent<SVGProperties & ExtraGlamorousProps>
-
-  config: Config
 }
 
 interface ThemeProps {


### PR DESCRIPTION
**What**:

Remove useDisplayNameInClassName and config

**Why**:

Because they are being removed from the glamorous api

https://github.com/paypal/glamorous/pull/247

**How**:


**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Ready to be merged
- [x] Added myself to contributors table

This also contains a commit which fixes a seperate issue in the `glamorous.test.tsx` which had managed to sneak into the snapshot as well.
