### PR TITLE
feat(typescript): add shouldClassNameUpdate typing

### DIFF
--- a/other/TYPESCRIPT_USAGE.md
+++ b/other/TYPESCRIPT_USAGE.md
@@ -12,13 +12,24 @@ The typings for
 * creating your own glamorous component factories
 * using built-in glamorous component factories
 are complete.
+* using `shouldClassNameUpdate`
 
 ```
 // Creating your own
-glamorous(Component)<Props>(/* styleArgument */)
+glamorous(Component)(/* styleArgument */)
 
 // Using built-in
 glamorous.div<Props>(/* styleArgument */)
+
+// Using shouldClassNameUpdate
+glamorous(Component, {
+  shouldClassNameUpdate: (props, prevProps, context, prevContext) => props !== prevProps
+})(/* styleArgument */)
+
+// Using shouldClassNameUpdate with Context
+glamorous<Props, Context>(Component, {
+  shouldClassNameUpdate: (props, prevProps, context, prevContext) => context !== prevContext
+})(/* styleArgument */)
 ```
 
 #### glamorousComponentFactory arguments

--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -44,8 +44,8 @@ test/should-fail.test.tsx(112,3): error TS2344: Type 'ThemeProps' does not satis
 test/should-fail.test.tsx(121,7): error TS2451: Cannot redeclare block-scoped variable 'NonGlamorousThemedComponent'.
 test/should-fail.test.tsx(122,3): error TS2344: Type 'PropsWithoutTheme' does not satisfy the constraint '{ theme: any; }'.
   Property 'theme' is missing in type 'PropsWithoutTheme'.
-test/should-fail.test.tsx(131,3): error TS2345: Argument of type '{ displayName: number; }' is not assignable to parameter of type 'Partial<GlamorousOptions> | undefined'.
-  Type '{ displayName: number; }' is not assignable to type 'Partial<GlamorousOptions>'.
+test/should-fail.test.tsx(131,3): error TS2345: Argument of type '{ displayName: number; }' is not assignable to parameter of type 'Partial<GlamorousOptions<object, object>> | undefined'.
+  Type '{ displayName: number; }' is not assignable to type 'Partial<GlamorousOptions<object, object>>'.
     Types of property 'displayName' are incompatible.
       Type 'number' is not assignable to type 'string | undefined'.
 test/should-fail.test.tsx(146,20): error TS2339: Property 'visibles' does not exist on type 'ExampleComponentProps & { theme: object; }'.
@@ -63,5 +63,14 @@ test/should-fail.test.tsx(159,4): error TS2345: Argument of type 'StatelessCompo
         Types of property 'visible' are incompatible.
           Type 'boolean' is not assignable to type 'string'.
 test/should-fail.test.tsx(160,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
+test/should-fail.test.tsx(175,15): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateProps'. Did you mean 'color'?
+test/should-fail.test.tsx(182,62): error TS2345: Argument of type '{ shouldClassNameUpdate: (props: ShouldClassNameUpdateProps, previousProps: ShouldClassNameUpdate...' is not assignable to parameter of type 'Partial<GlamorousOptions<ShouldClassNameUpdateProps, object>> | undefined'.
+  Type '{ shouldClassNameUpdate: (props: ShouldClassNameUpdateProps, previousProps: ShouldClassNameUpdate...' is not assignable to type 'Partial<GlamorousOptions<ShouldClassNameUpdateProps, object>>'.
+    Types of property 'shouldClassNameUpdate' are incompatible.
+      Type '(props: ShouldClassNameUpdateProps, previousProps: ShouldClassNameUpdateProps, context: object, p...' is not assignable to type '((props: ShouldClassNameUpdateProps, prevProps: ShouldClassNameUpdateProps, context: object, prev...'.
+        Type '(props: ShouldClassNameUpdateProps, previousProps: ShouldClassNameUpdateProps, context: object, p...' is not assignable to type '(props: ShouldClassNameUpdateProps, prevProps: ShouldClassNameUpdateProps, context: object, prevC...'.
+          Type 'false | 1' is not assignable to type 'boolean'.
+            Type '1' is not assignable to type 'boolean'.
+test/should-fail.test.tsx(198,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
 "
 `;

--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -22,17 +22,17 @@ test/should-fail.test.tsx(42,3): error TS2345: Argument of type '() => { float: 
 test/should-fail.test.tsx(48,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
   Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
     Property 'push' is missing in type '() => { float: \\"cat\\"; }'.
-test/should-fail.test.tsx(64,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(64,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps, object>'.
+  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps, object>)[]'.
     Property 'length' is missing in type '{ fillRule: \\"cat\\"; }'.
-test/should-fail.test.tsx(70,3): error TS2345: Argument of type '() => { fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '() => { fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(70,3): error TS2345: Argument of type '() => { fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps, object>'.
+  Type '() => { fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps, object>)[]'.
     Property 'push' is missing in type '() => { fillRule: \\"cat\\"; }'.
-test/should-fail.test.tsx(76,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(76,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps, object>'.
+  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps, object>)[]'.
     Property 'length' is missing in type '{ float: \\"cat\\"; }'.
-test/should-fail.test.tsx(82,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(82,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps, object>'.
+  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps, object>)[]'.
     Property 'push' is missing in type '() => { float: \\"cat\\"; }'.
 test/should-fail.test.tsx(100,24): error TS2551: Property 'colors' does not exist on type 'ExampleTheme'. Did you mean 'color'?
 test/should-fail.test.tsx(111,7): error TS2451: Cannot redeclare block-scoped variable 'NonGlamorousThemedComponent'.
@@ -48,5 +48,20 @@ test/should-fail.test.tsx(131,3): error TS2345: Argument of type '{ displayName:
   Type '{ displayName: number; }' is not assignable to type 'Partial<GlamorousOptions>'.
     Types of property 'displayName' are incompatible.
       Type 'number' is not assignable to type 'string | undefined'.
+test/should-fail.test.tsx(146,20): error TS2339: Property 'visibles' does not exist on type 'ExampleComponentProps & { theme: object; }'.
+test/should-fail.test.tsx(152,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
+  Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps>'.
+    Types of property 'visible' are incompatible.
+      Type '\\"string\\"' is not assignable to type 'boolean'.
+test/should-fail.test.tsx(153,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
+  Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps>'.
+    Property 'visible' is missing in type '{}'.
+test/should-fail.test.tsx(159,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type 'Component<{ visible: string; } & GlamorousProps>'.
+  Type 'StatelessComponent<ExampleComponentProps>' is not assignable to type 'StatelessComponent<{ visible: string; } & GlamorousProps>'.
+    Type 'ExampleComponentProps' is not assignable to type '{ visible: string; } & GlamorousProps'.
+      Type 'ExampleComponentProps' is not assignable to type '{ visible: string; }'.
+        Types of property 'visible' are incompatible.
+          Type 'boolean' is not assignable to type 'string'.
+test/should-fail.test.tsx(160,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
 "
 `;

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -137,7 +137,7 @@ const theme = {
 export const Balloon = () => (
   <ThemeProvider theme={theme}>
     <Divider color="blue">
-      <DividerInsideDivider color="blue">
+      <DividerInsideDivider>
         <Static>Static</Static>
         <StyleFunction color="blue">
           Hello
@@ -189,7 +189,10 @@ class ClassToWrap extends React.Component<ClassToWrapProps, object> {
 const WrappedClass = glamorous(ClassToWrap)({})
 
 const useWrappedClass = (
-  <WrappedClass test={10} />
+  <WrappedClass
+    test={10}
+    className=''
+  />
 )
 
 // React Stateless Wrapped Component
@@ -276,4 +279,31 @@ glamorous(
   {
     displayName: 'example'
   },
+)
+
+// custom glamorous component factory
+
+interface ExampleComponentProps {
+  visible: boolean
+}
+
+const ExampleComponent: React.SFC<ExampleComponentProps> = () => <div />
+
+const StyledExampleComponent = glamorous(ExampleComponent)(
+  (props) => ({
+    display: props.visible ? 'none' : 'hidden'
+  })
+)
+
+const usingStyledExampleComponent = (
+  <div>
+    <StyledExampleComponent
+      visible={false}
+    />
+    <StyledExampleComponent
+      visible={false}
+      className=""
+      theme={{}}
+    />
+  </div>
 )

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -307,3 +307,38 @@ const usingStyledExampleComponent = (
     />
   </div>
 )
+
+// shouldClassNameUpdate
+
+interface ShouldClassNameUpdateProps {
+  color: string
+}
+
+const TestShouldClassNameUpdate: React.SFC<ShouldClassNameUpdateProps> = () => <div />
+
+const pureDivFactory = glamorous(TestShouldClassNameUpdate, {
+  shouldClassNameUpdate: (props, previousProps, context, previousContext) => {
+    if (props.color !== props.color) {
+      return false
+    }
+    return true
+  },
+})
+
+
+interface ShouldClassNameUpdateContext {
+  color: string
+}
+
+const pureDivFactory2 = glamorous<ShouldClassNameUpdateProps, ShouldClassNameUpdateContext>(TestShouldClassNameUpdate, {
+  shouldClassNameUpdate: (props, previousProps, context, previousContext) => {
+    if (context.color !== previousContext.color) {
+      return false
+    }
+
+    return true
+  },
+})
+
+
+const Div = pureDivFactory({marginLeft: 1})

--- a/test/should-fail.test.tsx
+++ b/test/should-fail.test.tsx
@@ -161,3 +161,44 @@ const StyledExampleComponent2 = glamorous<{
     display: props.visible ? 'none' : 'hidden'
   })
 )
+
+// shouldClassNameUpdate
+
+interface ShouldClassNameUpdateProps {
+  color: string
+}
+
+const TestShouldClassNameUpdate: React.SFC<ShouldClassNameUpdateProps> = () => <div />
+
+const pureDivFactory0 = glamorous(TestShouldClassNameUpdate, {
+  shouldClassNameUpdate: (props, previousProps, context, previousContext) => {
+    if (props.colors !== props.color) {
+      return false
+    }
+    return true
+  },
+})
+
+const pureDivFactory1 = glamorous(TestShouldClassNameUpdate, {
+  shouldClassNameUpdate: (props, previousProps, context, previousContext) => {
+    if (props.color !== props.color) {
+      return false
+    }
+    return 1
+  },
+})
+
+
+interface ShouldClassNameUpdateContext {
+  color: string
+}
+
+const pureDivFactory2 = glamorous<ShouldClassNameUpdateProps, ShouldClassNameUpdateContext>(TestShouldClassNameUpdate, {
+  shouldClassNameUpdate: (props, previousProps, context, previousContext) => {
+    if (context.colors !== previousContext.color) {
+      return false
+    }
+
+    return true
+  },
+})

--- a/test/should-fail.test.tsx
+++ b/test/should-fail.test.tsx
@@ -132,3 +132,32 @@ glamorous(
     displayName: 0
   },
 )
+
+// custom glamorous component factory
+
+interface ExampleComponentProps {
+  visible: boolean
+}
+
+const ExampleComponent: React.SFC<ExampleComponentProps> = () => <div />
+
+const StyledExampleComponent = glamorous(ExampleComponent)(
+  (props) => ({
+    display: props.visibles ? 'none' : 'hidden'
+  })
+)
+
+const usingStyledExampleComponent = (
+  <div>
+    <StyledExampleComponent visible="string" />
+    <StyledExampleComponent/>
+  </div>
+)
+
+const StyledExampleComponent2 = glamorous<{
+  visible: string
+}>(ExampleComponent)(
+  (props) => ({
+    display: props.visible ? 'none' : 'hidden'
+  })
+)

--- a/typings/built-in-component-factories.d.ts
+++ b/typings/built-in-component-factories.d.ts
@@ -1,18 +1,18 @@
 import { SVGProperties } from './svg-properties'
 import { CSSProperties } from './css-properties'
 import {
-  GlamorousComponentFactory,
+  BuiltInGlamorousComponentFactory,
 } from './component-factory'
 
 export type HTMLGlamorousComponentFactory<
   HTMLElement,
   Properties
-> = GlamorousComponentFactory<React.HTMLProps<HTMLElement>, Properties>
+> = BuiltInGlamorousComponentFactory<React.HTMLProps<HTMLElement>, Properties>
 
 export type SVGGlamorousComponentFactory<
   SVGElement,
   Attributes
-> = GlamorousComponentFactory<React.SVGAttributes<SVGElement>, Attributes>
+> = BuiltInGlamorousComponentFactory<React.SVGAttributes<SVGElement>, Attributes>
 
 export interface HTMLComponentFactory {
   a: HTMLGlamorousComponentFactory<HTMLAnchorElement, CSSProperties>

--- a/typings/component-factory.ts
+++ b/typings/component-factory.ts
@@ -32,11 +32,20 @@ export type StyleArgument<Properties, Props, Theme> =
   | StyleFunction<Properties, Props, Theme>
   | StyleArray<Properties, Props, Theme>
 
-export interface GlamorousComponentFactory<Element, Properties> {
+export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
   <Props, Theme = object>(
     ...styles: StyleArgument<Properties, Props, Theme>[]
   ): GlamorousComponent<
-    Element,
+    ElementProps,
+    Props
+  >;
+}
+
+export interface GlamorousComponentFactory<ExternalProps, Properties> {
+  <Props, Theme = object>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps, Theme>[]
+  ): GlamorousComponent<
+    ExternalProps,
     Props
   >;
 }

--- a/typings/glamorous-component.d.ts
+++ b/typings/glamorous-component.d.ts
@@ -27,18 +27,13 @@ export interface WithComponent<Element, Props> {
   >
 }
 
-type OmitTheme<
-  Props extends { theme?: any },
-> = Omit<Props, "theme">
-
-
-export type GlamorousComponent<Element, Props> = React.ComponentClass<
-  & Element
-  & OmitTheme<Props>
+export type GlamorousComponent<ExternalProps, Props> = React.ComponentClass<
   & ExtraGlamorousProps
+  & ExternalProps
+  // & Props
 > & {
   withComponent: WithComponent<
-    Element,
-    OmitTheme<Props>
+    ExternalProps,
+    Props
   >
 }

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -53,17 +53,20 @@ type OmitInternals<
   Props extends { className?: string, theme?: object }
 > = Omit<Props, "className" | "theme">
 
+type GlamorousProps = { className?: string, theme?: object }
+
 export interface GlamorousInterface extends HTMLComponentFactory, SVGComponentFactory {
   // This overload is needed due to a union return of CSSProperties | SVGProperties
   // resulting in a loss of typesafety on function arguments
-  <Props extends { className?: string, theme?: object }>(
-    component: Component<Props>,
+  <ExternalProps, Context = object>(
+    component: Component<ExternalProps & GlamorousProps>,
     options?: Partial<GlamorousOptions>,
-  ): GlamorousComponentFactory<OmitInternals<Props>, CSSProperties>
-  <Props extends { className?: string, theme?: object }>(
-    component: Component<Props>,
+  ): GlamorousComponentFactory<ExternalProps, CSSProperties>
+
+  <ExternalProps, Context = object>(
+    component: Component<ExternalProps & GlamorousProps>,
     options?: Partial<GlamorousOptions>,
-  ): GlamorousComponentFactory<OmitInternals<Props>, SVGProperties>
+  ): GlamorousComponentFactory<ExternalProps, SVGProperties>
 
   Div: React.StatelessComponent<CSSProperties & ExtraGlamorousProps>
   Svg: React.StatelessComponent<SVGProperties & ExtraGlamorousProps>

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -16,6 +16,8 @@ import {
   StyleFunction,
   StyleArray,
   StyleArgument,
+
+  BuiltInGlamorousComponentFactory,
   GlamorousComponentFactory,
 } from './component-factory'
 import { CSSProperties } from './css-properties'
@@ -35,15 +37,19 @@ export {
   StyleArray,
   StyleArgument,
 
+  BuiltInGlamorousComponentFactory,
   GlamorousComponentFactory,
+
   HTMLComponentFactory,
   SVGComponentFactory,
 }
 
-export interface GlamorousOptions {
+export interface GlamorousOptions<Props, Context> {
   displayName: string
   rootEl: string | Element
   forwardProps: String[]
+  shouldClassNameUpdate:
+    (props: Props, prevProps: Props, context: Context, prevContext: Context) => boolean
 }
 
 export type Component<T> = React.ComponentClass<T> | React.StatelessComponent<T>
@@ -60,12 +66,12 @@ export interface GlamorousInterface extends HTMLComponentFactory, SVGComponentFa
   // resulting in a loss of typesafety on function arguments
   <ExternalProps, Context = object>(
     component: Component<ExternalProps & GlamorousProps>,
-    options?: Partial<GlamorousOptions>,
+    options?: Partial<GlamorousOptions<ExternalProps, Context>>,
   ): GlamorousComponentFactory<ExternalProps, CSSProperties>
 
   <ExternalProps, Context = object>(
     component: Component<ExternalProps & GlamorousProps>,
-    options?: Partial<GlamorousOptions>,
+    options?: Partial<GlamorousOptions<ExternalProps, Context>>,
   ): GlamorousComponentFactory<ExternalProps, SVGProperties>
 
   Div: React.StatelessComponent<CSSProperties & ExtraGlamorousProps>


### PR DESCRIPTION
**What/Why**:

Adds support for https://github.com/paypal/glamorous/pull/250

**How**:

Updated the typing to accept `shouldClassNameUpdate`. 

**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Ready to be merged
- [x] Added myself to contributors table

I also fixed an unrelated issue around looseness in the typing of component factories creation where when passed a component glamorous did not automatically work out it's Props as this issue was making it hard to test.
