### PR TITLE
feat(typescript): create component factories via dom key

### DIFF
--- a/other/TYPESCRIPT_USAGE.md
+++ b/other/TYPESCRIPT_USAGE.md
@@ -17,6 +17,7 @@ are complete.
 ```
 // Creating your own
 glamorous(Component)(/* styleArgument */)
+glamorous('div')(/* styleArgument */)
 
 // Using built-in
 glamorous.div<Props>(/* styleArgument */)

--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -44,33 +44,38 @@ test/should-fail.test.tsx(112,3): error TS2344: Type 'ThemeProps' does not satis
 test/should-fail.test.tsx(121,7): error TS2451: Cannot redeclare block-scoped variable 'NonGlamorousThemedComponent'.
 test/should-fail.test.tsx(122,3): error TS2344: Type 'PropsWithoutTheme' does not satisfy the constraint '{ theme: any; }'.
   Property 'theme' is missing in type 'PropsWithoutTheme'.
-test/should-fail.test.tsx(131,3): error TS2345: Argument of type '{ displayName: number; }' is not assignable to parameter of type 'Partial<GlamorousOptions<object, object>> | undefined'.
-  Type '{ displayName: number; }' is not assignable to type 'Partial<GlamorousOptions<object, object>>'.
-    Types of property 'displayName' are incompatible.
-      Type 'number' is not assignable to type 'string | undefined'.
+test/should-fail.test.tsx(130,3): error TS2345: Argument of type 'StatelessComponent<object>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+  Type 'StatelessComponent<object>' is not assignable to type '\\"text\\"'.
 test/should-fail.test.tsx(146,20): error TS2339: Property 'visibles' does not exist on type 'ExampleComponentProps & { theme: object; }'.
-test/should-fail.test.tsx(152,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
+test/should-fail.test.tsx(158,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
   Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps>'.
     Types of property 'visible' are incompatible.
       Type '\\"string\\"' is not assignable to type 'boolean'.
-test/should-fail.test.tsx(153,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
+test/should-fail.test.tsx(159,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
   Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps>'.
     Property 'visible' is missing in type '{}'.
-test/should-fail.test.tsx(159,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type 'Component<{ visible: string; } & GlamorousProps>'.
-  Type 'StatelessComponent<ExampleComponentProps>' is not assignable to type 'StatelessComponent<{ visible: string; } & GlamorousProps>'.
-    Type 'ExampleComponentProps' is not assignable to type '{ visible: string; } & GlamorousProps'.
-      Type 'ExampleComponentProps' is not assignable to type '{ visible: string; }'.
-        Types of property 'visible' are incompatible.
-          Type 'boolean' is not assignable to type 'string'.
-test/should-fail.test.tsx(160,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
-test/should-fail.test.tsx(175,15): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateProps'. Did you mean 'color'?
-test/should-fail.test.tsx(182,62): error TS2345: Argument of type '{ shouldClassNameUpdate: (props: ShouldClassNameUpdateProps, previousProps: ShouldClassNameUpdate...' is not assignable to parameter of type 'Partial<GlamorousOptions<ShouldClassNameUpdateProps, object>> | undefined'.
-  Type '{ shouldClassNameUpdate: (props: ShouldClassNameUpdateProps, previousProps: ShouldClassNameUpdate...' is not assignable to type 'Partial<GlamorousOptions<ShouldClassNameUpdateProps, object>>'.
-    Types of property 'shouldClassNameUpdate' are incompatible.
-      Type '(props: ShouldClassNameUpdateProps, previousProps: ShouldClassNameUpdateProps, context: object, p...' is not assignable to type '((props: ShouldClassNameUpdateProps, prevProps: ShouldClassNameUpdateProps, context: object, prev...'.
-        Type '(props: ShouldClassNameUpdateProps, previousProps: ShouldClassNameUpdateProps, context: object, p...' is not assignable to type '(props: ShouldClassNameUpdateProps, prevProps: ShouldClassNameUpdateProps, context: object, prevC...'.
-          Type 'false | 1' is not assignable to type 'boolean'.
-            Type '1' is not assignable to type 'boolean'.
-test/should-fail.test.tsx(198,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
+test/should-fail.test.tsx(160,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+  Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
+    Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
+      Types of property 'visible' are incompatible.
+        Type '\\"string\\"' is not assignable to type 'boolean'.
+test/should-fail.test.tsx(161,5): error TS2322: Type '{}' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+  Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
+    Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
+      Property 'visible' is missing in type '{}'.
+test/should-fail.test.tsx(165,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
+  Type '{ allowReorder: false; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}, object>)[]'.
+    Property 'length' is missing in type '{ allowReorder: false; }'.
+test/should-fail.test.tsx(166,18): error TS2345: Argument of type '{ color: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
+  Type '{ color: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+    Property 'length' is missing in type '{ color: boolean; }'.
+test/should-fail.test.tsx(170,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+  Type 'StatelessComponent<ExampleComponentProps>' is not assignable to type '\\"text\\"'.
+test/should-fail.test.tsx(171,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
+test/should-fail.test.tsx(178,14): error TS2365: Operator '===' cannot be applied to types 'boolean' and '\\"\\"'.
+test/should-fail.test.tsx(192,15): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateProps'. Did you mean 'color'?
+test/should-fail.test.tsx(199,35): error TS2345: Argument of type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+  Type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to type '\\"text\\"'.
+test/should-fail.test.tsx(215,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
 "
 `;

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -307,6 +307,7 @@ const usingStyledExampleComponent = (
     />
   </div>
 )
+
 // shouldClassNameUpdate
 
 interface ShouldClassNameUpdateProps {
@@ -338,6 +339,5 @@ const pureDivFactory2 = glamorous<ShouldClassNameUpdateProps, ShouldClassNameUpd
     return true
   },
 })
-
 
 const Div = pureDivFactory({marginLeft: 1})

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -295,6 +295,24 @@ const StyledExampleComponent = glamorous(ExampleComponent)(
   })
 )
 
+const StyledExampleComponentHTMLKey = glamorous<{ visible: boolean }>('div')(
+  (props) => ({
+    display: props.visible ? 'none' : 'hidden'
+  })
+)
+
+const StyledExampleComponentSVGKey = glamorous<{ visible: boolean }>('circle')(
+  {
+    fill: 'black',
+  },
+  (props) => ({
+    display: props.visible ? 'none' : 'hidden'
+  })
+)
+
+glamorous('circle')({ allowReorder: 'yes' })
+glamorous('div')({ color: 'red' })
+
 const usingStyledExampleComponent = (
   <div>
     <StyledExampleComponent
@@ -305,6 +323,8 @@ const usingStyledExampleComponent = (
       className=""
       theme={{}}
     />
+    <StyledExampleComponentHTMLKey visible={false} />
+    <StyledExampleComponentSVGKey visible={false} />
   </div>
 )
 

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -307,7 +307,6 @@ const usingStyledExampleComponent = (
     />
   </div>
 )
-
 // shouldClassNameUpdate
 
 interface ShouldClassNameUpdateProps {

--- a/test/should-fail.test.tsx
+++ b/test/should-fail.test.tsx
@@ -147,18 +147,35 @@ const StyledExampleComponent = glamorous(ExampleComponent)(
   })
 )
 
+const StyledExampleComponentKey = glamorous<{ visible: boolean }>('div')(
+  (props) => ({
+    display: props.visible ? 'none' : 'hidden'
+  })
+)
+
 const usingStyledExampleComponent = (
   <div>
     <StyledExampleComponent visible="string" />
     <StyledExampleComponent/>
+    <StyledExampleComponentKey visible="string" />
+    <StyledExampleComponentKey/>
   </div>
 )
 
-const StyledExampleComponent2 = glamorous<{
+glamorous('circle')({ allowReorder: false })
+glamorous('div')({ color: false })
+
+glamorous<{
   visible: string
 }>(ExampleComponent)(
   (props) => ({
     display: props.visible ? 'none' : 'hidden'
+  })
+)
+
+glamorous<{ visible: boolean }>('div')(
+  (props) => ({
+    display: props.visible === '' ? 'none' : 'hidden'
   })
 )
 

--- a/typings/built-in-component-factories.d.ts
+++ b/typings/built-in-component-factories.d.ts
@@ -130,6 +130,7 @@ export interface HTMLComponentFactory {
   wbr: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
 }
 
+export type HTMLKey = keyof HTMLComponentFactory
 
 export interface SVGComponentFactory {
   circle: SVGGlamorousComponentFactory<SVGCircleElement, SVGProperties>
@@ -152,3 +153,5 @@ export interface SVGComponentFactory {
   text: SVGGlamorousComponentFactory<SVGTextElement, SVGProperties>
   tspan: SVGGlamorousComponentFactory<SVGTSpanElement, SVGProperties>
 }
+
+export type SVGKey = keyof SVGComponentFactory

--- a/typings/component-factory.ts
+++ b/typings/component-factory.ts
@@ -41,6 +41,15 @@ export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
   >;
 }
 
+export interface KeyGlamorousComponentFactory<ElementProps, Properties, ExternalProps> {
+  <Props, Theme = object>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps, object>[]
+  ): GlamorousComponent<
+    ElementProps & ExternalProps,
+    ExternalProps
+  >;
+}
+
 export interface GlamorousComponentFactory<ExternalProps, Properties> {
   <Props, Theme = object>(
     ...styles: StyleArgument<Properties, Props & ExternalProps, Theme>[]

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -5,7 +5,9 @@
 import * as React from 'react'
 import {
   HTMLComponentFactory,
+  HTMLKey,
   SVGComponentFactory,
+  SVGKey,
 } from './built-in-component-factories'
 import {
   GlamorousComponent,
@@ -18,6 +20,7 @@ import {
   StyleArgument,
 
   BuiltInGlamorousComponentFactory,
+  KeyGlamorousComponentFactory,
   GlamorousComponentFactory,
 } from './component-factory'
 import { CSSProperties } from './css-properties'
@@ -38,10 +41,13 @@ export {
   StyleArgument,
 
   BuiltInGlamorousComponentFactory,
+  KeyGlamorousComponentFactory,
   GlamorousComponentFactory,
 
   HTMLComponentFactory,
+  HTMLKey,
   SVGComponentFactory,
+  SVGKey,
 }
 
 export interface GlamorousOptions<Props, Context> {
@@ -73,6 +79,16 @@ export interface GlamorousInterface extends HTMLComponentFactory, SVGComponentFa
     component: Component<ExternalProps & GlamorousProps>,
     options?: Partial<GlamorousOptions<ExternalProps, Context>>,
   ): GlamorousComponentFactory<ExternalProps, SVGProperties>
+
+  <ExternalProps, Context = object>(
+    component: HTMLKey,
+    options?: Partial<GlamorousOptions<ExternalProps, Context>>,
+  ): KeyGlamorousComponentFactory<HTMLComponentFactory[HTMLKey], CSSProperties, ExternalProps>
+
+  <ExternalProps, Context = object>(
+    component: SVGKey,
+    options?: Partial<GlamorousOptions<ExternalProps, Context>>,
+  ): KeyGlamorousComponentFactory<SVGComponentFactory[SVGKey], SVGProperties, ExternalProps>
 
   Div: React.StatelessComponent<CSSProperties & ExtraGlamorousProps>
   Svg: React.StatelessComponent<SVGProperties & ExtraGlamorousProps>


### PR DESCRIPTION
**What**:
Provides support for glamorous component factories to be created with dom keys
https://github.com/paypal/glamorous/tree/6d806889e9991065f1243d4abdce9c0b6cd3a2ae#using-glamorous-composition

ie. `glamorous('div')`

**Why**:

**How**:

Added two new overloads to the `GlamorousInterface` for HTML and SVG tagsthat are typed to provide the same return type as the built-in glamorous component factories.

**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Ready to be merged
- [x] Added myself to contributors table

This topic branch is based off https://github.com/paypal/glamorous/pull/251.

https://github.com/luke-john/glamorous/commit/1b4413ce9a90c153a85531c95282ca4722375e7b is the only unique commit
