### PR TITLE
feat(withProps): add `withProps` helper API

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,59 @@ const Link = Button.withComponent('a')
 > Note: to override styles, you can do the same thing you do with a regular
 > component (`css` prop, wrap it in `glamorous()`, or regular `className` prop).
 
+#### withProps
+
+Sometimes it can be useful to apply props by default for a component. The
+simplest way to do this is by simply setting the `defaultProps` value on the
+glamorousComponent. But if you want a little more power and composition, then
+the `withProps` APIs can help.
+
+> These APIs are highly composable, it would be hard to show you all the
+> examples of how this composes together. Just know that it behaves as you might
+> expect.
+
+```javascript
+// when creating a glamorousComponentFactory
+const bigDivFactory = glamorous('div', {withProps: {big: true}})
+const BigDiv = bigDivFactory(({big}) => ({fontSize: big ? 20 : 10}))
+render(<BigDiv />) // renders with fontSize: 20
+render(<BigDiv big={false} />) // renders with fontSize: 10
+
+// applying props to an existing component
+const MyDiv = glamorous.div(({small}) => ({fontSize: small ? 10 : 20}))
+const SmallDiv = MyDiv.withProps({small: true})
+render(<SmallDiv />) // renders with fontSize: 20
+```
+
+Based on those examples, there are three places you can apply props to a
+glamorous component. How these props are composed together applies in this order
+(where later has more precedence):
+
+1. Creating a `glamorousComponentFactory`
+2. Directly on a `glamorousComponent` with the `.withProps` function
+3. When rendering a component (just like applying props to a regular components)
+
+In addition to this, you can also have dynamic props. And these props don't have
+to be used for glamorous styling, any valid props will be forwarded to the
+element:
+
+```javascript
+const BoldDiv = glamorous
+  .div(({bold}) => ({fontWeight: bold ? 'bold' : 'normal'}))
+  .withProps(({bold}) => ({className: bold ? 'bold-element' : 'normal-element'}))
+
+render(<BoldDiv />) // renders <div class="bold-element" /> with fontWeight: bold
+render(<BoldDiv bold={false} />) // renders <div class="normal-element" /> with fontWeight: normal
+```
+
+The `.withProps` API can also accept any number of arguments. They are called
+with `(accumulatedProps, context)`. `accumulatedProps` refers to the props that
+are known so far in the accumulation of the props which makes this API highly
+composable. Finally, the `withProps` APIs can also accept arrays of
+objects/functions. You can pretty much do anything you want with this API.
+
+> NOTE: This is a shallow merge (uses `Object.assign`)
+
 ### Theming
 
 `glamorous` fully supports theming using a special `<ThemeProvider>` component.

--- a/src/__tests__/__snapshots__/index.with-props.js.snap
+++ b/src/__tests__/__snapshots__/index.with-props.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`composes well with other glamorous components 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  margin-top: 1px;
+  font-size: 1px;
+  font-weight: 300;
+}
+
+<div
+  class="glamor-0"
+/>
+`;

--- a/src/__tests__/index.with-props.js
+++ b/src/__tests__/index.with-props.js
@@ -1,0 +1,120 @@
+import React from 'react'
+import {render} from 'enzyme'
+import glamorous from '../'
+
+const expectContext = expect.objectContaining({__glamorous__: undefined})
+
+test('allows you to specify props as an object', () => {
+  const withPropsObject = {propA: 'a', propB: 'b'}
+  const dynamicStyles = jest.fn()
+  const MyDiv = glamorous.div(dynamicStyles).withProps(withPropsObject)
+  render(<MyDiv otherProp={true} />)
+  expect(dynamicStyles).toHaveBeenCalledTimes(1)
+  expect(dynamicStyles).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ...withPropsObject,
+      otherProp: true,
+    }),
+    expectContext,
+  )
+})
+
+test('composes well with other glamorous components', () => {
+  const MyDiv = glamorous
+    .div({marginTop: 1}, () => ({fontSize: 1}))
+    .withProps()
+  const MyIdDiv = glamorous(MyDiv)(() => ({fontWeight: 300})).withProps()
+  expect(render(<MyIdDiv />)).toMatchSnapshot()
+})
+
+test('allows you to specify props as a function', () => {
+  const withPropsObject = {propA: 'a', propB: 'b'}
+  const withPropsFunction = jest.fn(() => withPropsObject)
+  const dynamicStyles = jest.fn()
+  const MyDiv = glamorous.div(dynamicStyles).withProps(withPropsFunction)
+  render(<MyDiv otherProp={true} />)
+  expect(withPropsFunction).toHaveBeenCalledTimes(1)
+  expect(withPropsFunction).toHaveBeenCalledWith(
+    expect.objectContaining({
+      otherProp: true,
+    }),
+    expectContext,
+  )
+  expect(dynamicStyles).toHaveBeenCalledTimes(1)
+  expect(dynamicStyles).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ...withPropsObject,
+      otherProp: true,
+    }),
+    expectContext,
+  )
+})
+
+test('allows you to provide any number of arguments for props', () => {
+  // important bits of this test:
+  // 1. props shallowly compose together
+  // 2. composition order (later has greater precedence):
+  //   1. withProps option when createing a glamorousComponentFactory
+  //   2. arguments to withProps (in the same order as Object.assign)
+  //   3. props applied to the element when rendered
+  // 3. composition works as you might expect when wrapping a glamorousComponent
+  const withPropsObject1 = {propA: 1, propB: 1}
+  const withPropsObject2 = {propB: 2, propC: 2}
+  const withPropsObject3 = {propC: 3, propD: 3}
+  const withPropsObject4 = {propD: 4, propE: 4}
+  const withPropsObject5 = {propE: 5, propF: 5}
+  const withPropsObject6 = {propF: 6, propG: 6}
+  const withPropsObject7 = {propG: 7, propH: 7}
+  const propsRendered = {propZ: 99, propA: 99}
+
+  const withPropsFunction2 = jest.fn(() => withPropsObject2)
+  const withPropsFunction4 = jest.fn(() => withPropsObject4)
+  const dynamicStyles = jest.fn()
+  const MyDiv = glamorous('div', {withProps: withPropsObject1})({}).withProps(
+    withPropsFunction2,
+  )
+  const MyComposedDiv = glamorous(MyDiv, {
+    withProps: [withPropsObject3, withPropsFunction4],
+  })(dynamicStyles).withProps(withPropsObject5, [
+    withPropsObject6,
+    withPropsObject7,
+  ])
+  render(<MyComposedDiv {...propsRendered} />)
+
+  expect(withPropsFunction2).toHaveBeenCalledTimes(1)
+  expect(withPropsFunction2).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ...withPropsObject1,
+      ...propsRendered,
+    }),
+    expectContext,
+  )
+
+  expect(withPropsFunction4).toHaveBeenCalledTimes(1)
+  expect(withPropsFunction4).toHaveBeenCalledWith(
+    expect.objectContaining({
+      // this order is important and part of what we're testing here
+      ...withPropsObject1,
+      ...withPropsObject2,
+      ...withPropsObject3,
+      ...propsRendered,
+    }),
+    expectContext,
+  )
+
+  expect(dynamicStyles).toHaveBeenCalledTimes(1)
+  expect(dynamicStyles).toHaveBeenCalledWith(
+    expect.objectContaining({
+      // this order is important and part of what we're testing here
+      ...withPropsObject1,
+      ...withPropsObject2,
+      ...withPropsObject3,
+      ...withPropsObject4,
+      ...withPropsObject5,
+      ...withPropsObject6,
+      ...withPropsObject7,
+      ...propsRendered,
+    }),
+    expectContext,
+  )
+})


### PR DESCRIPTION
**What**: This adds the `withProps` helper API

<!-- Why are these changes necessary? -->
**Why**: Closes #133 

<!-- How were these changes implemented? -->
**How**:
- Store the `propsToApply` on the `GlamorousComponent`
- expose a way to create a new glamorous component that combines the `propsToApply` given.
- When rendering, reduce all the `propsToApply` with the `props` given to a single props object

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
