### PR TITLE
feat(typescript): add typing for `withProps` helper APIi

### DIFF
--- a/other/TYPESCRIPT_USAGE.md
+++ b/other/TYPESCRIPT_USAGE.md
@@ -14,7 +14,7 @@ The typings for
 are complete.
 * using `shouldClassNameUpdate`
 
-```
+```tsx
 // Creating your own
 glamorous(Component)(/* styleArgument */)
 glamorous('div')(/* styleArgument */)
@@ -31,13 +31,22 @@ glamorous(Component, {
 glamorous<Props, Context>(Component, {
   shouldClassNameUpdate: (props, prevProps, context, prevContext) => context !== prevContext
 })(/* styleArgument */)
+
+// Using withProps
+glamorous(Component, {
+  withProps: {primaryColor: 'red'}
+})((props) => ({/* props = { primaryColor: string } */})
+
+const WithPropsComponent = glamorous(Component)(/* styleArgument */).withProps(withProps: {primaryColor: 'red'})
+...
+<WithPropsComponent primaryColor='' /> // primaryColor is an optional prop of string type based on the above
 ```
 
 #### glamorousComponentFactory arguments
 
 By providing the typings for Props and Theme to Glamorous when setting up your component factory they will be typed on the props argument for function arguments automatically.
 
-```ts
+```tsx
 interface Props {
   noPadding?: boolean,
   theme: { color: string }
@@ -90,7 +99,7 @@ Possible support via [glamors typings](https://github.com/threepointone/glamor/b
 
 When using glamorous in a library that you are generating definition files for you will need to include the following import and export to get around a typescript issue [Microsoft/TypeScript/issues/5938](https://github.com/Microsoft/TypeScript/issues/5938).
 
-```ts
+```tsx
 import glamorous, { ExtraGlamorousProps, WithComponent  } from "glamorous"
 export { ExtraGlamorousProps, WithComponent }
 ```

--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -22,17 +22,17 @@ test/should-fail.test.tsx(42,3): error TS2345: Argument of type '() => { float: 
 test/should-fail.test.tsx(48,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
   Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
     Property 'push' is missing in type '() => { float: \\"cat\\"; }'.
-test/should-fail.test.tsx(64,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps, object>'.
-  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps, object>)[]'.
+test/should-fail.test.tsx(64,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object, object>'.
+  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object, obje...'.
     Property 'length' is missing in type '{ fillRule: \\"cat\\"; }'.
-test/should-fail.test.tsx(70,3): error TS2345: Argument of type '() => { fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps, object>'.
-  Type '() => { fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps, object>)[]'.
+test/should-fail.test.tsx(70,3): error TS2345: Argument of type '() => { fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object, object>'.
+  Type '() => { fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object, obje...'.
     Property 'push' is missing in type '() => { fillRule: \\"cat\\"; }'.
-test/should-fail.test.tsx(76,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps, object>'.
-  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps, object>)[]'.
+test/should-fail.test.tsx(76,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object, object>'.
+  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object, obje...'.
     Property 'length' is missing in type '{ float: \\"cat\\"; }'.
-test/should-fail.test.tsx(82,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps, object>'.
-  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps, object>)[]'.
+test/should-fail.test.tsx(82,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object, object>'.
+  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object, obje...'.
     Property 'push' is missing in type '() => { float: \\"cat\\"; }'.
 test/should-fail.test.tsx(100,24): error TS2551: Property 'colors' does not exist on type 'ExampleTheme'. Did you mean 'color'?
 test/should-fail.test.tsx(111,7): error TS2451: Cannot redeclare block-scoped variable 'NonGlamorousThemedComponent'.
@@ -46,13 +46,13 @@ test/should-fail.test.tsx(122,3): error TS2344: Type 'PropsWithoutTheme' does no
   Property 'theme' is missing in type 'PropsWithoutTheme'.
 test/should-fail.test.tsx(130,3): error TS2345: Argument of type 'StatelessComponent<object>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<object>' is not assignable to type '\\"text\\"'.
-test/should-fail.test.tsx(146,20): error TS2339: Property 'visibles' does not exist on type 'ExampleComponentProps & { theme: object; }'.
+test/should-fail.test.tsx(146,20): error TS2339: Property 'visibles' does not exist on type 'ExampleComponentProps & object & { theme: object; }'.
 test/should-fail.test.tsx(158,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
-  Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps>'.
+  Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object>'.
     Types of property 'visible' are incompatible.
       Type '\\"string\\"' is not assignable to type 'boolean'.
 test/should-fail.test.tsx(159,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
-  Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps>'.
+  Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object>'.
     Property 'visible' is missing in type '{}'.
 test/should-fail.test.tsx(160,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
   Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
@@ -63,11 +63,11 @@ test/should-fail.test.tsx(161,5): error TS2322: Type '{}' is not assignable to t
   Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
     Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
       Property 'visible' is missing in type '{}'.
-test/should-fail.test.tsx(165,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
-  Type '{ allowReorder: false; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}, object>)[]'.
+test/should-fail.test.tsx(165,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, object & {}, object>'.
+  Type '{ allowReorder: false; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, object & {}, object>)[]'.
     Property 'length' is missing in type '{ allowReorder: false; }'.
-test/should-fail.test.tsx(166,18): error TS2345: Argument of type '{ color: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '{ color: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(166,18): error TS2345: Argument of type '{ color: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, object & {}, object>'.
+  Type '{ color: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, object & {}, object>)[]'.
     Property 'length' is missing in type '{ color: boolean; }'.
 test/should-fail.test.tsx(170,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<ExampleComponentProps>' is not assignable to type '\\"text\\"'.
@@ -77,5 +77,29 @@ test/should-fail.test.tsx(192,15): error TS2551: Property 'colors' does not exis
 test/should-fail.test.tsx(199,35): error TS2345: Argument of type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to type '\\"text\\"'.
 test/should-fail.test.tsx(215,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
+test/should-fail.test.tsx(225,11): error TS2345: Argument of type '\\"div\\"' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+test/should-fail.test.tsx(232,3): error TS2345: Argument of type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; }, object>'.
+  Type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; }, object>)[]'.
+    Property 'push' is missing in type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }'.
+test/should-fail.test.tsx(237,1): error TS2554: Expected 1 arguments, but got 0.
+test/should-fail.test.tsx(238,30): error TS2345: Argument of type '\\"\\"' is not assignable to parameter of type 'object'.
+test/should-fail.test.tsx(239,30): error TS2345: Argument of type 'false' is not assignable to parameter of type 'object'.
+test/should-fail.test.tsx(265,19): error TS2322: Type '{ d: \\"\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+  Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
+test/should-fail.test.tsx(266,19): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+  Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
+    Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
+      Types of property 'primaryColor' are incompatible.
+        Type '1' is not assignable to type 'string | undefined'.
+test/should-fail.test.tsx(267,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
+test/should-fail.test.tsx(268,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
+  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & Partial<{ primaryColor: string; }>>'.
+    Types of property 'primaryColor' are incompatible.
+      Type '1' is not assignable to type 'string | undefined'.
+test/should-fail.test.tsx(269,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
+test/should-fail.test.tsx(270,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
+  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & object & Partial<{ primaryColor: string; }>>'.
+    Types of property 'primaryColor' are incompatible.
+      Type '1' is not assignable to type 'string | undefined'.
 "
 `;

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -5,7 +5,7 @@ import glamorous, { withTheme, ThemeProvider } from "../";
 // https://github.com/Microsoft/TypeScript/issues/5938
 import { ExtraGlamorousProps } from "../";
 
-import { WithComponent } from "../"
+import { WithComponent, WithProps } from "../"
 
 // Partial<Properties>
 const Static = glamorous.div({
@@ -361,3 +361,40 @@ const pureDivFactory2 = glamorous<ShouldClassNameUpdateProps, ShouldClassNameUpd
 })
 
 const Div = pureDivFactory({marginLeft: 1})
+
+// withProps
+
+const WithPropsDiv = glamorous('div', {
+  withProps: {primaryColor: 'red'}
+})(
+  (props) => ({
+    color: props.primaryColor
+  })
+)
+
+const SimpleComponent = () => <div />
+
+const WithPropsSimpleComponent = glamorous(SimpleComponent, {
+  withProps: {primaryColor: 'red'}
+})(
+  (props) => ({
+    color: props.primaryColor
+  })
+)
+
+const MethodWithPropsComponent = glamorous(SimpleComponent)({}).withProps({
+  primaryColor: 'red'
+})
+
+const useWithProps = (
+  <div>
+    <WithPropsDiv />
+    <WithPropsDiv primaryColor="red" />
+    <WithPropsSimpleComponent />
+    <WithPropsSimpleComponent primaryColor="red" />
+    <MethodWithPropsComponent />
+    <MethodWithPropsComponent primaryColor="1" />
+  </div>
+)
+
+// withProps method

--- a/test/should-fail.test.tsx
+++ b/test/should-fail.test.tsx
@@ -219,3 +219,55 @@ const pureDivFactory2 = glamorous<ShouldClassNameUpdateProps, ShouldClassNameUpd
     return true
   },
 })
+
+// withProps
+
+glamorous('div', {
+  withProps: ''
+})
+
+glamorous('div', {
+  withProps: { visible: false }
+})(
+  (props) => ({
+    primaryColor: props.visible
+  })
+)
+
+glamorous('div')().withProps()
+glamorous('div')().withProps('')
+glamorous('div')().withProps(false)
+
+const WithPropsDiv = glamorous('div', {
+  withProps: {primaryColor: 'red'}
+})(
+  (props) => ({
+    primaryColor: props.primaryColor
+  })
+)
+
+const SimpleComponent = () => <div />
+
+const MethodWithPropsComponent = glamorous(SimpleComponent)({}).withProps({
+  primaryColor: 'red'
+})
+
+const WithPropsSimpleComponent = glamorous(SimpleComponent, {
+  withProps: {primaryColor: 'red'}
+})(
+  (props) => ({
+    primaryColor: props.primaryColor
+  })
+)
+
+const useWithProps = (
+  <div>
+    <WithPropsDiv d="" />
+    <WithPropsDiv primaryColor={1} />
+    <WithPropsSimpleComponent d="" />
+    <WithPropsSimpleComponent primaryColor={1} />
+    <MethodWithPropsComponent d="" />
+    <MethodWithPropsComponent primaryColor={1} />
+
+  </div>
+)

--- a/typings/component-factory.ts
+++ b/typings/component-factory.ts
@@ -41,20 +41,20 @@ export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
   >;
 }
 
-export interface KeyGlamorousComponentFactory<ElementProps, Properties, ExternalProps> {
+export interface KeyGlamorousComponentFactory<ElementProps, Properties, ExternalProps, DefaultProps> {
   <Props, Theme = object>(
-    ...styles: StyleArgument<Properties, Props & ExternalProps, object>[]
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps, object>[]
   ): GlamorousComponent<
-    ElementProps & ExternalProps,
+    ElementProps & ExternalProps & Partial<DefaultProps>,
     ExternalProps
   >;
 }
 
-export interface GlamorousComponentFactory<ExternalProps, Properties> {
+export interface GlamorousComponentFactory<ExternalProps, Properties, DefaultProps> {
   <Props, Theme = object>(
-    ...styles: StyleArgument<Properties, Props & ExternalProps, Theme>[]
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps, Theme>[]
   ): GlamorousComponent<
-    ExternalProps,
+    ExternalProps & Partial<DefaultProps>,
     Props
   >;
 }

--- a/typings/glamorous-component.d.ts
+++ b/typings/glamorous-component.d.ts
@@ -18,22 +18,25 @@ export interface ExtraGlamorousProps {
   theme?: object;
 }
 
-export interface WithComponent<Element, Props> {
-  (
+export interface WithComponent<ExternalProps, Props> {
+  withComponent: (
     component: string | Component<Props>
-  ): GlamorousComponent<
-    Element,
-    Props
-  >
-}
-
-export type GlamorousComponent<ExternalProps, Props> = React.ComponentClass<
-  & ExtraGlamorousProps
-  & ExternalProps
-  // & Props
-> & {
-  withComponent: WithComponent<
+  ) => GlamorousComponent<
     ExternalProps,
     Props
   >
 }
+
+export interface WithProps<ExternalProps, Props> {
+  withProps: <DefaultProps extends object>(
+    props: DefaultProps
+  ) => GlamorousComponent<
+    ExternalProps & Partial<DefaultProps>,
+    Props
+  >
+}
+
+export type GlamorousComponent<ExternalProps, Props> =
+  & React.ComponentClass<ExtraGlamorousProps & ExternalProps>
+  & WithComponent<ExternalProps, Props>
+  & WithProps<ExternalProps, Props>

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -13,6 +13,7 @@ import {
   GlamorousComponent,
   ExtraGlamorousProps,
   WithComponent,
+  WithProps,
 } from './glamorous-component'
 import {
   StyleFunction,
@@ -35,6 +36,7 @@ export {
   GlamorousComponent,
   ExtraGlamorousProps,
   WithComponent,
+  WithProps,
 
   StyleFunction,
   StyleArray,
@@ -50,12 +52,13 @@ export {
   SVGKey,
 }
 
-export interface GlamorousOptions<Props, Context> {
+export interface GlamorousOptions<Props, Context, DefaultProps> {
   displayName: string
   rootEl: string | Element
   forwardProps: String[]
   shouldClassNameUpdate:
     (props: Props, prevProps: Props, context: Context, prevContext: Context) => boolean
+  withProps: DefaultProps
 }
 
 export type Component<T> = React.ComponentClass<T> | React.StatelessComponent<T>
@@ -70,25 +73,29 @@ type GlamorousProps = { className?: string, theme?: object }
 export interface GlamorousInterface extends HTMLComponentFactory, SVGComponentFactory {
   // This overload is needed due to a union return of CSSProperties | SVGProperties
   // resulting in a loss of typesafety on function arguments
-  <ExternalProps, Context = object>(
+  <ExternalProps, Context = object, DefaultProps extends object = object>(
     component: Component<ExternalProps & GlamorousProps>,
-    options?: Partial<GlamorousOptions<ExternalProps, Context>>,
-  ): GlamorousComponentFactory<ExternalProps, CSSProperties>
+    options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
+  ): GlamorousComponentFactory<ExternalProps, CSSProperties, DefaultProps>
 
-  <ExternalProps, Context = object>(
+  <ExternalProps, Context = object, DefaultProps extends object = object>(
     component: Component<ExternalProps & GlamorousProps>,
-    options?: Partial<GlamorousOptions<ExternalProps, Context>>,
-  ): GlamorousComponentFactory<ExternalProps, SVGProperties>
+    options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
+  ): GlamorousComponentFactory<ExternalProps, SVGProperties, DefaultProps>
 
-  <ExternalProps, Context = object>(
+  <ExternalProps, Context = object, DefaultProps extends object = object>(
     component: HTMLKey,
-    options?: Partial<GlamorousOptions<ExternalProps, Context>>,
-  ): KeyGlamorousComponentFactory<HTMLComponentFactory[HTMLKey], CSSProperties, ExternalProps>
+    options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
+  ): KeyGlamorousComponentFactory<
+    HTMLComponentFactory[HTMLKey], CSSProperties, ExternalProps, DefaultProps
+  >
 
-  <ExternalProps, Context = object>(
+  <ExternalProps, Context = object, DefaultProps extends object = object>(
     component: SVGKey,
-    options?: Partial<GlamorousOptions<ExternalProps, Context>>,
-  ): KeyGlamorousComponentFactory<SVGComponentFactory[SVGKey], SVGProperties, ExternalProps>
+    options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
+  ): KeyGlamorousComponentFactory<
+    SVGComponentFactory[SVGKey], SVGProperties, ExternalProps, DefaultProps
+  >
 
   Div: React.StatelessComponent<CSSProperties & ExtraGlamorousProps>
   Svg: React.StatelessComponent<SVGProperties & ExtraGlamorousProps>


### PR DESCRIPTION
**What and Why**:

This adds the typing required to use the new `withProps` helper API
introduced by https://github.com/paypal/glamorous/pull/255/files.

**How**:
Adding withProps to the GlamorousOptions with a generic type that is also passed to the ComponentFactory allowing the typing to be automatically inferred on usage.

**Checklist**:
- [x] Documentation
- [x] Tests
- [x] Ready to be merged
- [x] Added myself to contributors table