### PR TITLE
feat: expose propsAreCssOverrides and composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,22 @@ Note that this is _not_ the same as `shouldComponentUpdate`. Your component will
 still be rerendered. `shouldClassNameUpdate` is only for allowing you to opt-out
 of generating the `className` unnecessarily.
 
+#### propsAreCssOverrides
+
+This allows you to use props as CSS. You always have the `css` prop, but
+sometimes it's really nice to use just the props as CSS.
+
+```javascript
+const MyDiv = glamorous('div', {propsAreCssOverrides: true})({
+  margin: 1,
+  fontSize: 1,
+})
+render(<MyDiv margin={2} css={{':hover': {fontWeight: 'bold'}}} />)
+// renders <div /> with margin: 2, fontSize: 1, and fontWeight: bold on hover
+```
+
+> You can also compose the built-in components: `glamorous(glamorous.Div)(/* styles */)`
+
 #### withComponent
 
 In some cases you might want to just copy the styles of an already created

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -51,6 +51,30 @@ exports[`can accept functions which return string class names 1`] = `
 />
 `;
 
+exports[`can compose built-in glamorous components 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  margin: 2px;
+  font-size: 1px;
+}
+
+<div
+  class="glamor-0"
+/>
+`;
+
+exports[`can create custom built-in glamorous components 1`] = `
+.glamor-0,
+[data-glamor-0] {
+  margin: 2px;
+  font-size: 1px;
+}
+
+<div
+  class="glamor-0"
+/>
+`;
+
 exports[`can use pre-built glamorous components with css attributes 1`] = `
 .glamor-0,
 [data-glamor-0] {

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -50,6 +50,19 @@ test('can use pre-built glamorous components with css prop', () => {
   ).toMatchSnapshot()
 })
 
+test('can compose built-in glamorous components', () => {
+  const MyDiv = glamorous(glamorous.Div)({margin: 1, fontSize: 1})
+  expect(render(<MyDiv margin={2} />)).toMatchSnapshot()
+})
+
+test('can create custom built-in glamorous components', () => {
+  const MyDiv = glamorous('div', {propsAreCssOverrides: true})({
+    margin: 1,
+    fontSize: 1,
+  })
+  expect(render(<MyDiv margin={2} />)).toMatchSnapshot()
+})
+
 test('the css prop accepts "GlamorousStyles"', () => {
   const object = {fontSize: 12}
   expect(render(<glamorous.Section css={object} />)).toMatchSnapshot(

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -25,7 +25,13 @@ function createGlamorous(splitProps) {
   */
   function glamorous(
     comp,
-    {rootEl, displayName, shouldClassNameUpdate, forwardProps = []} = {},
+    {
+      rootEl,
+      displayName,
+      shouldClassNameUpdate,
+      forwardProps = [],
+      propsAreCssOverrides = comp.propsAreCssOverrides,
+    } = {},
   ) {
     return glamorousComponentFactory
 
@@ -120,7 +126,12 @@ function createGlamorous(splitProps) {
           forwardProps,
           displayName,
         }),
-        {withComponent, isGlamorousComponent: true, previous: null},
+        {
+          withComponent,
+          isGlamorousComponent: true,
+          previous: null,
+          propsAreCssOverrides,
+        },
       )
       return GlamorousComponent
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: expose `propsAreCssOverrides` and composition

<!-- Why are these changes necessary? -->
**Why**: Closes #256

<!-- How were these changes implemented? -->
**How**:
- adding `propsAreCssOverrides` to the options provided to the `glamorousComponentFactoryFactory` and defaulting that to the `component.propsAreCssOverrides`
- Testing it

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
