### PR TITLE
feat(typescript): accept property arrays for fallbacks

### DIFF
--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -46,60 +46,75 @@ test/should-fail.test.tsx(122,3): error TS2344: Type 'PropsWithoutTheme' does no
   Property 'theme' is missing in type 'PropsWithoutTheme'.
 test/should-fail.test.tsx(130,3): error TS2345: Argument of type 'StatelessComponent<object>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<object>' is not assignable to type '\\"text\\"'.
+test/should-fail.test.tsx(145,3): error TS2345: Argument of type '(props: ExampleComponentProps & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, ExampleComponentProps & object, object>'.
+  Type '(props: ExampleComponentProps & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, ExampleComponentProps & object, o...'.
+    Property 'push' is missing in type '(props: ExampleComponentProps & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }'.
 test/should-fail.test.tsx(146,20): error TS2339: Property 'visibles' does not exist on type 'ExampleComponentProps & object & { theme: object; }'.
-test/should-fail.test.tsx(158,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
+test/should-fail.test.tsx(151,3): error TS2345: Argument of type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object, object>'.
+  Type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; } & object, o...'.
+    Property 'push' is missing in type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }'.
+test/should-fail.test.tsx(161,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
   Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object>'.
     Types of property 'visible' are incompatible.
       Type '\\"string\\"' is not assignable to type 'boolean'.
-test/should-fail.test.tsx(159,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
+test/should-fail.test.tsx(162,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
   Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object>'.
     Property 'visible' is missing in type '{}'.
-test/should-fail.test.tsx(160,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+test/should-fail.test.tsx(163,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
   Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
     Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
       Types of property 'visible' are incompatible.
         Type '\\"string\\"' is not assignable to type 'boolean'.
-test/should-fail.test.tsx(161,5): error TS2322: Type '{}' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+test/should-fail.test.tsx(164,5): error TS2322: Type '{}' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
   Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
     Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
       Property 'visible' is missing in type '{}'.
-test/should-fail.test.tsx(165,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, object & {}, object>'.
+test/should-fail.test.tsx(168,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, object & {}, object>'.
   Type '{ allowReorder: false; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, object & {}, object>)[]'.
     Property 'length' is missing in type '{ allowReorder: false; }'.
-test/should-fail.test.tsx(166,18): error TS2345: Argument of type '{ color: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, object & {}, object>'.
+test/should-fail.test.tsx(169,18): error TS2345: Argument of type '{ color: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, object & {}, object>'.
   Type '{ color: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, object & {}, object>)[]'.
     Property 'length' is missing in type '{ color: boolean; }'.
-test/should-fail.test.tsx(170,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+test/should-fail.test.tsx(173,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<ExampleComponentProps>' is not assignable to type '\\"text\\"'.
-test/should-fail.test.tsx(171,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
-test/should-fail.test.tsx(178,14): error TS2365: Operator '===' cannot be applied to types 'boolean' and '\\"\\"'.
-test/should-fail.test.tsx(192,15): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateProps'. Did you mean 'color'?
-test/should-fail.test.tsx(199,35): error TS2345: Argument of type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+test/should-fail.test.tsx(174,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
+test/should-fail.test.tsx(180,3): error TS2345: Argument of type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object, object>'.
+  Type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; } & object, o...'.
+    Property 'push' is missing in type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }'.
+test/should-fail.test.tsx(181,14): error TS2365: Operator '===' cannot be applied to types 'boolean' and '\\"\\"'.
+test/should-fail.test.tsx(195,15): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateProps'. Did you mean 'color'?
+test/should-fail.test.tsx(202,35): error TS2345: Argument of type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to type '\\"text\\"'.
-test/should-fail.test.tsx(215,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
-test/should-fail.test.tsx(225,11): error TS2345: Argument of type '\\"div\\"' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
-test/should-fail.test.tsx(232,3): error TS2345: Argument of type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; }, object>'.
+test/should-fail.test.tsx(218,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
+test/should-fail.test.tsx(228,11): error TS2345: Argument of type '\\"div\\"' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+test/should-fail.test.tsx(235,3): error TS2345: Argument of type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; }, object>'.
   Type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; }, object>)[]'.
     Property 'push' is missing in type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }'.
-test/should-fail.test.tsx(237,1): error TS2554: Expected 1 arguments, but got 0.
-test/should-fail.test.tsx(238,30): error TS2345: Argument of type '\\"\\"' is not assignable to parameter of type 'object'.
-test/should-fail.test.tsx(239,30): error TS2345: Argument of type 'false' is not assignable to parameter of type 'object'.
-test/should-fail.test.tsx(265,19): error TS2322: Type '{ d: \\"\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+test/should-fail.test.tsx(240,1): error TS2554: Expected 1 arguments, but got 0.
+test/should-fail.test.tsx(241,30): error TS2345: Argument of type '\\"\\"' is not assignable to parameter of type 'object'.
+test/should-fail.test.tsx(242,30): error TS2345: Argument of type 'false' is not assignable to parameter of type 'object'.
+test/should-fail.test.tsx(268,19): error TS2322: Type '{ d: \\"\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
   Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
-test/should-fail.test.tsx(266,19): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+test/should-fail.test.tsx(269,19): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
   Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
     Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
       Types of property 'primaryColor' are incompatible.
         Type '1' is not assignable to type 'string | undefined'.
-test/should-fail.test.tsx(267,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
-test/should-fail.test.tsx(268,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
+test/should-fail.test.tsx(270,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
+test/should-fail.test.tsx(271,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
   Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & Partial<{ primaryColor: string; }>>'.
     Types of property 'primaryColor' are incompatible.
       Type '1' is not assignable to type 'string | undefined'.
-test/should-fail.test.tsx(269,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
-test/should-fail.test.tsx(270,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
+test/should-fail.test.tsx(272,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
+test/should-fail.test.tsx(273,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
   Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & object & Partial<{ primaryColor: string; }>>'.
     Types of property 'primaryColor' are incompatible.
       Type '1' is not assignable to type 'string | undefined'.
+test/should-fail.test.tsx(278,15): error TS2345: Argument of type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
+  Type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+    Property 'length' is missing in type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }'.
+test/should-fail.test.tsx(283,18): error TS2345: Argument of type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
+  Type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}, object>)[]'.
+    Property 'length' is missing in type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }'.
 "
 `;

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -7,10 +7,32 @@ import { ExtraGlamorousProps } from "../";
 
 import { WithComponent, WithProps } from "../"
 
-// Partial<Properties>
+// Properties
 const Static = glamorous.div({
   "fontSize": 20,
   "textAlign": "center",
+});
+
+// Properties Array
+glamorous.div({
+  overflowWrap: "break-word",
+  display: ["flex", "block"],
+});
+
+glamorous.circle({
+  textAlign: "center",
+  display: ["marker", "block"],
+});
+
+// pseudo and complex Properties
+glamorous.div({
+  ':active': {
+    "fontSize": 10,
+  },
+  '&:active': {
+    "fontSize": 20,
+    "textAlign": "center",
+  },
 });
 
 // classname string style
@@ -291,13 +313,13 @@ const ExampleComponent: React.SFC<ExampleComponentProps> = () => <div />
 
 const StyledExampleComponent = glamorous(ExampleComponent)(
   (props) => ({
-    display: props.visible ? 'none' : 'hidden'
+    display: props.visible ? 'none' : 'block'
   })
 )
 
 const StyledExampleComponentHTMLKey = glamorous<{ visible: boolean }>('div')(
   (props) => ({
-    display: props.visible ? 'none' : 'hidden'
+    display: props.visible ? 'none' : 'block'
   })
 )
 
@@ -306,7 +328,7 @@ const StyledExampleComponentSVGKey = glamorous<{ visible: boolean }>('circle')(
     fill: 'black',
   },
   (props) => ({
-    display: props.visible ? 'none' : 'hidden'
+    display: props.visible ? 'none' : 'block'
   })
 )
 

--- a/test/should-fail.test.tsx
+++ b/test/should-fail.test.tsx
@@ -141,17 +141,20 @@ interface ExampleComponentProps {
 
 const ExampleComponent: React.SFC<ExampleComponentProps> = () => <div />
 
-const StyledExampleComponent = glamorous(ExampleComponent)(
+glamorous(ExampleComponent)(
   (props) => ({
     display: props.visibles ? 'none' : 'hidden'
   })
 )
 
-const StyledExampleComponentKey = glamorous<{ visible: boolean }>('div')(
+glamorous<{ visible: boolean }>('div')(
   (props) => ({
     display: props.visible ? 'none' : 'hidden'
   })
 )
+
+const StyledExampleComponent = glamorous(ExampleComponent)()
+const StyledExampleComponentKey = glamorous<{ visible: boolean }>('div')()
 
 const usingStyledExampleComponent = (
   <div>
@@ -268,6 +271,16 @@ const useWithProps = (
     <WithPropsSimpleComponent primaryColor={1} />
     <MethodWithPropsComponent d="" />
     <MethodWithPropsComponent primaryColor={1} />
-
   </div>
 )
+
+// Properties Array
+glamorous.div({
+  textAlign: "center",
+  display: ["block", "flexs"],
+})
+
+glamorous.circle({
+  textAlign: "center",
+  display: ["flexs", "block"],
+})

--- a/typings/css-properties.d.ts
+++ b/typings/css-properties.d.ts
@@ -1,11 +1,12 @@
+import { SingleOrArray } from './helpers'
+
 // See CSS 3 CSS-wide keywords https://www.w3.org/TR/css3-values/#common-keywords
 // See CSS 3 Explicit Defaulting https://www.w3.org/TR/css-cascade-3/#defaulting-keywords
 // "all CSS properties can accept these values"
 type CSSWideKeyword = 'initial' | 'inherit' | 'unset'
 
 // Based on [CSSProperties from React types](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts)
-export interface CSSPropertiesComplete {
-
+export interface CSSPropertiesCompleteSingle {
   /**
    * Aligns a flex container's lines within the flex container when there is extra space in the cross-axis, similar to how justify-content aligns individual items within the main-axis.
    */
@@ -451,7 +452,25 @@ export interface CSSPropertiesComplete {
   /**
    * This property specifies the type of rendering box used for an element. It is a shorthand property for many other display properties.
    */
-  display?: CSSWideKeyword | string
+  display?:
+    /** turn off the display of an element and its descendants */
+    | 'none'
+    /** <display-outside> values. */
+    | 'block' | 'inline' | 'run-in'
+    /** <display-inside> values. */
+    | 'flow' | 'flow-root' | 'table' | 'flex' | 'grid' | 'ruby' | 'subgrid'
+    /** <display-outside> plus <display-inside> values */
+    | 'block flow' | 'inline table' | 'flex run-in'
+    /** <display-listitem> values */
+    | 'list-item' | 'list-item block' | 'list-item inline' | 'list-item flow' | 'list-item flow-root' | 'list-item block flow' | 'list-item block flow-root' | 'flow list-item block'
+    /** <display-internal> values. */
+    | 'table-row-group' | 'table-header-group' | 'table-footer-group' | 'table-row' | 'table-cell' | 'table-column-group' | 'table-column' | 'table-caption' | 'ruby-base' | 'ruby-text' | 'ruby-base-container' | 'ruby-text-container'
+    /** <display-box> values. */
+    | 'contents' | 'none'
+    /** <display-legacy> values. */
+    | 'inline-block' | 'inline-list-item' | 'inline-table' | 'inline-flex' | 'inline-grid'
+    /** global values. */
+    | CSSWideKeyword
 
   /**
    * The ‘fill’ property paints the interior of the given graphical element. The area to be painted consists of any areas inside the outline of the shape. To determine the inside of the shape, all subpaths are considered, and the interior is determined according to the rules associated with the current value of the ‘fill-rule’ property. The zero-width geometric outline of a shape is included in the area to be painted.
@@ -1466,7 +1485,9 @@ export interface CSSPropertiesComplete {
    * See CSS zoom descriptor https://drafts.csswg.org/css-device-adapt/#zoom-desc
    */
   zoom?: CSSWideKeyword | string | number
+}
 
+interface CSSPropertiesPseudo {
   ':active'?: CSSProperties
   ':any-link'?: CSSProperties
   ':checked'?: CSSProperties
@@ -1526,10 +1547,18 @@ export interface CSSPropertiesComplete {
   '::selection'?: CSSProperties
 }
 
+type CSSPropertiesComplete = SingleOrArray<
+  CSSPropertiesCompleteSingle,
+  keyof CSSPropertiesCompleteSingle
+>
+
 export interface CSSPropertiesLossy {
-  [propertyName: string]: string | number | CSSProperties | undefined
+  [propertyName: string]:
+    | string | number | CSSPropertiesComplete | undefined
+    | Array<CSSPropertiesComplete[keyof CSSPropertiesComplete]>
 }
 
 type CSSProperties =
   & CSSPropertiesComplete
+  & CSSPropertiesPseudo
   & CSSPropertiesLossy

--- a/typings/helpers.d.ts
+++ b/typings/helpers.d.ts
@@ -14,3 +14,7 @@ export type Omit<
   T,
   Diff<keyof T, K>
 >
+
+export type SingleOrArray<Properties, T extends keyof Properties> = {
+  [P in T]: Properties[P] | Array<Properties[P]>
+}

--- a/typings/svg-properties.d.ts
+++ b/typings/svg-properties.d.ts
@@ -1,10 +1,11 @@
-import { CSSProperties } from './css-properties.d'
+import { SingleOrArray } from './helpers'
+import { CSSProperties, CSSPropertiesCompleteSingle } from './css-properties.d'
 
 // Taken from React.SVGAttributes with the following added to work around issue where Partials
 // accept arbitrary functions
 // [propertyName: string]: string | number | SVGProperties | undefined
 
-export interface SVGPropertiesComplete {
+export interface SVGPropertiesCompleteSingle {
   // Attributes which also defined in HTMLAttributes
   // See comment in SVGDOMPropertyConfig.js
   className?: string;
@@ -68,7 +69,14 @@ export interface SVGPropertiesComplete {
   descent?: number | string;
   diffuseConstant?: number | string;
   direction?: number | string;
-  display?: number | string;
+  // taken from https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/display
+  /** The display attribute lets you control the rendering of graphical or container elements */
+  display?:
+    | 'inline' | 'block' | 'list-item' | 'run-in' | 'compact' | 'marker'
+    | 'table' | 'inline-table' | 'table-row-group' | 'table-header-group'
+    | 'table-footer-group' | 'table-row' | 'table-column-group' | 'table-column'
+    | 'table-cell' | 'table-caption' | 'none' | 'inherit'
+    | CSSPropertiesCompleteSingle['display']
   divisor?: number | string;
   dominantBaseline?: number | string;
   dur?: number | string;
@@ -269,8 +277,15 @@ export interface SVGPropertiesComplete {
   zoomAndPan?: string;
 }
 
+type SVGPropertiesComplete = SingleOrArray<
+  SVGPropertiesCompleteSingle,
+  keyof SVGPropertiesCompleteSingle
+>
+
 export interface SVGPropertiesLossy {
-  [propertyName: string]: string | number | SVGProperties | undefined
+  [propertyName: string]:
+    | string | number | SVGProperties | undefined
+    | Array<SVGPropertiesCompleteSingle[keyof SVGPropertiesCompleteSingle]>
 }
 
 type SVGProperties =


### PR DESCRIPTION
**What**:

Adding typing for styles to accept arrays

**Why**:

As reported in #259 glamor accepts array values and uses them to create fallback values

https://github.com/threepointone/glamor/blob/00349761d9ee56c781dff448b3a9979e3d05e042/docs/howto.md#fallback-values

**How**:

Adding typings and tests.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
- [x] Added myself to contributors table
