### PR TITLE
chore(typescript): consistant theme handling

### DIFF
--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -1,120 +1,113 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Typescript expected failures 1`] = `
-"test/should-fail.test.tsx(10,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
-  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}, object>)[]'.
+"test/should-fail.test.tsx(10,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
+  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}>)[]'.
     Property 'length' is missing in type '{ fillRule: \\"cat\\"; }'.
-test/should-fail.test.tsx(16,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
-  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}, object>)[]'.
+test/should-fail.test.tsx(16,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
+  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}>)[]'.
     Property 'length' is missing in type '{ fillRule: \\"cat\\"; }'.
-test/should-fail.test.tsx(22,3): error TS2345: Argument of type '() => { fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
-  Type '() => { fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}, object>)[]'.
+test/should-fail.test.tsx(22,3): error TS2345: Argument of type '() => { fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
+  Type '() => { fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}>)[]'.
     Property 'push' is missing in type '() => { fillRule: \\"cat\\"; }'.
-test/should-fail.test.tsx(30,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(30,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
+  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
     Property 'length' is missing in type '{ float: \\"cat\\"; }'.
-test/should-fail.test.tsx(36,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(36,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
+  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
     Property 'length' is missing in type '{ float: \\"cat\\"; }'.
-test/should-fail.test.tsx(42,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(42,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
+  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
     Property 'push' is missing in type '() => { float: \\"cat\\"; }'.
-test/should-fail.test.tsx(48,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(48,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
+  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
     Property 'push' is missing in type '() => { float: \\"cat\\"; }'.
-test/should-fail.test.tsx(64,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object, object>'.
-  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object, obje...'.
+test/should-fail.test.tsx(64,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object>'.
+  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
     Property 'length' is missing in type '{ fillRule: \\"cat\\"; }'.
-test/should-fail.test.tsx(70,3): error TS2345: Argument of type '() => { fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object, object>'.
-  Type '() => { fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object, obje...'.
+test/should-fail.test.tsx(70,3): error TS2345: Argument of type '() => { fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object>'.
+  Type '() => { fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
     Property 'push' is missing in type '() => { fillRule: \\"cat\\"; }'.
-test/should-fail.test.tsx(76,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object, object>'.
-  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object, obje...'.
+test/should-fail.test.tsx(76,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object>'.
+  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
     Property 'length' is missing in type '{ float: \\"cat\\"; }'.
-test/should-fail.test.tsx(82,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object, object>'.
-  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object, obje...'.
+test/should-fail.test.tsx(82,3): error TS2345: Argument of type '() => { float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object>'.
+  Type '() => { float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
     Property 'push' is missing in type '() => { float: \\"cat\\"; }'.
 test/should-fail.test.tsx(100,24): error TS2551: Property 'colors' does not exist on type 'ExampleTheme'. Did you mean 'color'?
-test/should-fail.test.tsx(111,7): error TS2451: Cannot redeclare block-scoped variable 'NonGlamorousThemedComponent'.
-test/should-fail.test.tsx(112,3): error TS2344: Type 'ThemeProps' does not satisfy the constraint '{ theme: NotExampleTheme; }'.
-  Types of property 'theme' are incompatible.
-    Type 'ExampleTheme' is not assignable to type 'NotExampleTheme'.
-      Types of property 'color' are incompatible.
-        Type 'string' is not assignable to type 'number'.
-test/should-fail.test.tsx(121,7): error TS2451: Cannot redeclare block-scoped variable 'NonGlamorousThemedComponent'.
-test/should-fail.test.tsx(122,3): error TS2344: Type 'PropsWithoutTheme' does not satisfy the constraint '{ theme: any; }'.
+test/should-fail.test.tsx(111,3): error TS2344: Type 'PropsWithoutTheme' does not satisfy the constraint '{ theme: any; }'.
   Property 'theme' is missing in type 'PropsWithoutTheme'.
-test/should-fail.test.tsx(130,3): error TS2345: Argument of type 'StatelessComponent<object>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+test/should-fail.test.tsx(119,3): error TS2345: Argument of type 'StatelessComponent<object>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<object>' is not assignable to type '\\"text\\"'.
-test/should-fail.test.tsx(145,3): error TS2345: Argument of type '(props: ExampleComponentProps & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, ExampleComponentProps & object, object>'.
-  Type '(props: ExampleComponentProps & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, ExampleComponentProps & object, o...'.
-    Property 'push' is missing in type '(props: ExampleComponentProps & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }'.
-test/should-fail.test.tsx(146,20): error TS2339: Property 'visibles' does not exist on type 'ExampleComponentProps & object & { theme: object; }'.
-test/should-fail.test.tsx(151,3): error TS2345: Argument of type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object, object>'.
-  Type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; } & object, o...'.
-    Property 'push' is missing in type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }'.
-test/should-fail.test.tsx(161,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
-  Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object>'.
+test/should-fail.test.tsx(134,3): error TS2345: Argument of type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { theme: any; } & ExampleComponentProps & object>'.
+  Type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { theme: any; } & ExampleComponen...'.
+    Property 'push' is missing in type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }'.
+test/should-fail.test.tsx(135,20): error TS2339: Property 'visibles' does not exist on type '{ theme: any; } & ExampleComponentProps & object'.
+test/should-fail.test.tsx(140,3): error TS2345: Argument of type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object>'.
+  Type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; } & object>)[]'.
+    Property 'push' is missing in type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }'.
+test/should-fail.test.tsx(150,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
+  Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object & Pick<{ theme: any; }, never>>'.
     Types of property 'visible' are incompatible.
       Type '\\"string\\"' is not assignable to type 'boolean'.
-test/should-fail.test.tsx(162,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
-  Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object>'.
+test/should-fail.test.tsx(151,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
+  Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object & Pick<{ theme: any; }, never>>'.
     Property 'visible' is missing in type '{}'.
-test/should-fail.test.tsx(163,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+test/should-fail.test.tsx(152,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
   Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
     Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
       Types of property 'visible' are incompatible.
         Type '\\"string\\"' is not assignable to type 'boolean'.
-test/should-fail.test.tsx(164,5): error TS2322: Type '{}' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+test/should-fail.test.tsx(153,5): error TS2322: Type '{}' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
   Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
     Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
       Property 'visible' is missing in type '{}'.
-test/should-fail.test.tsx(168,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, object & {}, object>'.
-  Type '{ allowReorder: false; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, object & {}, object>)[]'.
+test/should-fail.test.tsx(157,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, object & {}>'.
+  Type '{ allowReorder: false; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, object & {}>)[]'.
     Property 'length' is missing in type '{ allowReorder: false; }'.
-test/should-fail.test.tsx(169,18): error TS2345: Argument of type '{ color: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, object & {}, object>'.
-  Type '{ color: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, object & {}, object>)[]'.
+test/should-fail.test.tsx(158,18): error TS2345: Argument of type '{ color: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, object & {}>'.
+  Type '{ color: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, object & {}>)[]'.
     Property 'length' is missing in type '{ color: boolean; }'.
-test/should-fail.test.tsx(173,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+test/should-fail.test.tsx(162,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<ExampleComponentProps>' is not assignable to type '\\"text\\"'.
-test/should-fail.test.tsx(174,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
-test/should-fail.test.tsx(180,3): error TS2345: Argument of type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object, object>'.
-  Type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; } & object, o...'.
-    Property 'push' is missing in type '(props: { visible: boolean; } & object & { theme: object; }) => { display: \\"none\\" | \\"hidden\\"; }'.
-test/should-fail.test.tsx(181,14): error TS2365: Operator '===' cannot be applied to types 'boolean' and '\\"\\"'.
-test/should-fail.test.tsx(195,15): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateProps'. Did you mean 'color'?
-test/should-fail.test.tsx(202,35): error TS2345: Argument of type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+test/should-fail.test.tsx(163,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
+test/should-fail.test.tsx(169,3): error TS2345: Argument of type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object>'.
+  Type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; } & object>)[]'.
+    Property 'push' is missing in type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }'.
+test/should-fail.test.tsx(170,14): error TS2365: Operator '===' cannot be applied to types 'boolean' and '\\"\\"'.
+test/should-fail.test.tsx(184,15): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateProps'. Did you mean 'color'?
+test/should-fail.test.tsx(191,35): error TS2345: Argument of type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to type '\\"text\\"'.
-test/should-fail.test.tsx(218,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
-test/should-fail.test.tsx(228,11): error TS2345: Argument of type '\\"div\\"' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
-test/should-fail.test.tsx(235,3): error TS2345: Argument of type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; }, object>'.
-  Type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; }, object>)[]'.
-    Property 'push' is missing in type '(props: { visible: boolean; } & { theme: object; }) => { primaryColor: boolean; }'.
-test/should-fail.test.tsx(240,1): error TS2554: Expected 1 arguments, but got 0.
-test/should-fail.test.tsx(241,30): error TS2345: Argument of type '\\"\\"' is not assignable to parameter of type 'object'.
-test/should-fail.test.tsx(242,30): error TS2345: Argument of type 'false' is not assignable to parameter of type 'object'.
-test/should-fail.test.tsx(268,19): error TS2322: Type '{ d: \\"\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+test/should-fail.test.tsx(207,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
+test/should-fail.test.tsx(217,11): error TS2345: Argument of type '\\"div\\"' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+test/should-fail.test.tsx(224,3): error TS2345: Argument of type '(props: { visible: boolean; }) => { primaryColor: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; }>'.
+  Type '(props: { visible: boolean; }) => { primaryColor: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; }>)[]'.
+    Property 'push' is missing in type '(props: { visible: boolean; }) => { primaryColor: boolean; }'.
+test/should-fail.test.tsx(229,1): error TS2554: Expected 1 arguments, but got 0.
+test/should-fail.test.tsx(230,30): error TS2345: Argument of type '\\"\\"' is not assignable to parameter of type 'object'.
+test/should-fail.test.tsx(231,30): error TS2345: Argument of type 'false' is not assignable to parameter of type 'object'.
+test/should-fail.test.tsx(257,19): error TS2322: Type '{ d: \\"\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
   Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
-test/should-fail.test.tsx(269,19): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+test/should-fail.test.tsx(258,19): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
   Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
     Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
       Types of property 'primaryColor' are incompatible.
         Type '1' is not assignable to type 'string | undefined'.
-test/should-fail.test.tsx(270,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
-test/should-fail.test.tsx(271,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
-  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & Partial<{ primaryColor: string; }>>'.
+test/should-fail.test.tsx(259,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
+test/should-fail.test.tsx(260,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
+  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & Partial<{ primaryColor: string; }> & Pick<{ theme: any; }, never>>'.
     Types of property 'primaryColor' are incompatible.
       Type '1' is not assignable to type 'string | undefined'.
-test/should-fail.test.tsx(272,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
-test/should-fail.test.tsx(273,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
-  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & object & Partial<{ primaryColor: string; }>>'.
+test/should-fail.test.tsx(261,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Pick<{ th...'.
+test/should-fail.test.tsx(262,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Pick<{ th...'.
+  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & object & Pick<{ theme: any; }, never> & Partial<{ primaryColor: st...'.
     Types of property 'primaryColor' are incompatible.
       Type '1' is not assignable to type 'string | undefined'.
-test/should-fail.test.tsx(278,15): error TS2345: Argument of type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}, object>'.
-  Type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}, object>)[]'.
+test/should-fail.test.tsx(267,15): error TS2345: Argument of type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
+  Type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
     Property 'length' is missing in type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }'.
-test/should-fail.test.tsx(283,18): error TS2345: Argument of type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}, object>'.
-  Type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}, object>)[]'.
+test/should-fail.test.tsx(272,18): error TS2345: Argument of type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
+  Type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}>)[]'.
     Property 'length' is missing in type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }'.
 "
 `;

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -1,17 +1,33 @@
 import * as React from "react";
-import glamorous, { withTheme, ThemeProvider } from "../";
+import glamorous, {
+  withTheme, ThemeProvider
+} from "../";
 
 // Needed if generating definition files
 // https://github.com/Microsoft/TypeScript/issues/5938
 import { ExtraGlamorousProps } from "../";
 
-import { WithComponent, WithProps } from "../"
+import { WithComponent, WithProps, CSSPropertiesPseudo, CSSPropertiesLossy } from "../"
 
 // Properties
 const Static = glamorous.div({
   "fontSize": 20,
   "textAlign": "center",
 });
+
+export interface StaticProps {
+  visible: boolean
+}
+
+const StaticWithProps = glamorous.div<StaticProps>(
+  (props) => ({
+    display: props.visible ? 'block' : 'none'
+  })
+)
+
+const useStatic = (
+  <StaticWithProps visible />
+)
 
 // Properties Array
 glamorous.div({
@@ -138,10 +154,9 @@ interface DividerInsideDividerProps {
 };
 
 // component styles
-const DividerInsideDivider = glamorous(Divider)<
-  object,
-  { main: { color: string; } }
->(
+const DividerInsideDivider = glamorous(Divider)<{
+  theme: { main: { color: string } }
+}>(
   {
     "fontSize": "10px",
   },
@@ -158,8 +173,12 @@ const theme = {
 
 export const Balloon = () => (
   <ThemeProvider theme={theme}>
-    <Divider color="blue">
-      <DividerInsideDivider>
+    <Divider theme={{
+      main: { color: "blue" }
+    }}>
+      <DividerInsideDivider theme={{
+        main: { color: "blue" }
+      }}>
         <Static>Static</Static>
         <StyleFunction color="blue">
           Hello
@@ -219,14 +238,26 @@ const useWrappedClass = (
 
 // React Stateless Wrapped Component
 
+export interface WrappedStatelessProps {
+  theme: {
+    visible: boolean
+  }
+}
+
 const StatelessToWrap: React.StatelessComponent<object> = () => (
   <div />
 )
 
-const WrappedStateless = glamorous(StatelessToWrap)({})
+const WrappedStateless = glamorous(StatelessToWrap)<WrappedStatelessProps>(
+  (props) => ({
+    display: props.theme.visible ? 'block' : 'none'
+  })
+)
 
 // Exported Component (for testing declaration generation)
-export const ExportTest = glamorous.div({})
+export const ExportTest = glamorous.div(
+  {}
+)
 
 // Theme Provider
 
@@ -272,8 +303,7 @@ const ComponentWithTheme: React.SFC<Props> = (props) => (
 )
 
 const NonGlamorousThemedComponent = withTheme<
-  Props,
-  ExampleTheme
+  Props
 >(ComponentWithTheme)
 
 

--- a/test/should-fail.test.tsx
+++ b/test/should-fail.test.tsx
@@ -103,17 +103,6 @@ const ComponentWithTheme: React.SFC<ThemeProps> = (props) => (
   </h3>
 )
 
-interface NotExampleTheme {
-  color: number
-}
-
-
-const NonGlamorousThemedComponent = withTheme<
-  ThemeProps,
-  NotExampleTheme
->(ComponentWithTheme)
-
-
 interface PropsWithoutTheme {
   title: string
 }

--- a/typings/component-factory.ts
+++ b/typings/component-factory.ts
@@ -1,60 +1,91 @@
 import { GlamorousComponent } from './glamorous-component'
+import { Omit } from './helpers'
 /**
  * StyleObject is an objects of Style Properties.
  *
  * @see {@link https://github.com/paypal/glamorous/blob/master/src/create-glamorous.js#L28-L131}
  */
 
-export interface StyleFunction<Properties, Props, Theme> {
-  (
-    props: Props & {
-      theme: Theme
-    }
-  ):
+export interface StyleFunction<Properties, Props> {
+  (props: Props):
     | Partial<Properties>
     | string
     | Array<
       | Partial<Properties>
       | string
-      | StyleFunction<Properties, Props, Theme>
+      | StyleFunction<Properties, Props>
     >
 }
 
-export type StyleArray<Properties, Props, Theme> = Array<
+export type StyleArray<Properties, Props> = Array<
   | Partial<Properties>
   | string
-  | StyleFunction<Properties, Props, Theme>
+  | StyleFunction<Properties, Props>
 >
 
-export type StyleArgument<Properties, Props, Theme> =
+export type StyleArgument<Properties, Props> =
   | Partial<Properties>
   | string
-  | StyleFunction<Properties, Props, Theme>
-  | StyleArray<Properties, Props, Theme>
+  | StyleFunction<Properties, Props>
+  | StyleArray<Properties, Props>
 
+// glamorous.div: without Theme
 export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
-  <Props, Theme = object>(
-    ...styles: StyleArgument<Properties, Props, Theme>[]
+  <Props>(
+    ...styles: StyleArgument<Properties, Props>[]
   ): GlamorousComponent<
-    ElementProps,
+    ElementProps & Props,
     Props
   >;
 }
 
-export interface KeyGlamorousComponentFactory<ElementProps, Properties, ExternalProps, DefaultProps> {
-  <Props, Theme = object>(
-    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps, object>[]
+// glamorous.div: with Theme
+export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
+  <Props extends { theme: any }>(
+    ...styles: StyleArgument<Properties, Props>[]
   ): GlamorousComponent<
-    ElementProps & ExternalProps & Partial<DefaultProps>,
+    ElementProps & Omit<Props, 'theme'>,
+    Props
+  >;
+}
+
+// glamorous('div'): without Theme
+export interface KeyGlamorousComponentFactory<ElementProps, Properties, ExternalProps, DefaultProps> {
+  <Props>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
+  ): GlamorousComponent<
+    ElementProps & ExternalProps & Partial<DefaultProps> & Props,
     ExternalProps
   >;
 }
 
+
+// glamorous('div'): with Theme
+export interface KeyGlamorousComponentFactory<ElementProps, Properties, ExternalProps, DefaultProps> {
+  <Props extends { theme?: any }>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
+  ): GlamorousComponent<
+    ElementProps & ExternalProps & Partial<DefaultProps> & Omit<Props, 'theme'>,
+    ExternalProps
+  >;
+}
+
+// glamorous(Component): without Theme
 export interface GlamorousComponentFactory<ExternalProps, Properties, DefaultProps> {
-  <Props, Theme = object>(
-    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps, Theme>[]
+  <Props>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
   ): GlamorousComponent<
     ExternalProps & Partial<DefaultProps>,
+    Props
+  >;
+}
+
+// glamorous(Component): with Theme
+export interface GlamorousComponentFactory<ExternalProps, Properties, DefaultProps> {
+  <Props extends { theme: any }>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
+  ): GlamorousComponent<
+    ExternalProps & Partial<DefaultProps> & Omit<Props, 'theme'>,
     Props
   >;
 }

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -24,14 +24,17 @@ import {
   KeyGlamorousComponentFactory,
   GlamorousComponentFactory,
 } from './component-factory'
-import { CSSProperties } from './css-properties'
-import { SVGProperties } from './svg-properties'
+import { CSSProperties, CSSPropertiesPseudo, CSSPropertiesLossy } from './css-properties'
+import { SVGProperties, SVGPropertiesLossy } from './svg-properties'
 
 import { Omit } from './helpers'
 
 export {
   CSSProperties,
+  CSSPropertiesPseudo,
+  CSSPropertiesLossy,
   SVGProperties,
+  SVGPropertiesLossy,
 
   GlamorousComponent,
   ExtraGlamorousProps,
@@ -107,21 +110,16 @@ interface ThemeProps {
 
 export class ThemeProvider extends React.Component<ThemeProps, any> { }
 
-type OmitTheme<
-  Props extends { theme: Theme },
-  Theme
-> = Omit<Props, "theme">
-
-export function withTheme<Props extends { theme: Theme }, Theme = {}>(
+export function withTheme<Props extends { theme: any }>(
   component: React.ComponentClass<Props>
 ): React.ComponentClass<
-  OmitTheme<Props, Theme>
+  Omit<Props, "theme">
 >
 
-export function withTheme<Props extends { theme: Theme }, Theme = {}>(
+export function withTheme<Props extends { theme: any }>(
   component: React.StatelessComponent<Props>
 ): React.StatelessComponent<
-  OmitTheme<Props, Theme>
+  Omit<Props, "theme">
 >
 
 declare const glamorous: GlamorousInterface


### PR DESCRIPTION
Noticed the theme was still being passed as a seperate generic when doing a screen capture for the release notes.

https://github.com/paypal/glamorous/pull/230#issuecomment-318878595

This behaviour is left over from when theme was passed as a seperate argument and had already been removed in some of the typing

**What**:

Removing all typings that had Theme as an additional generic to Props 

**Why**:

Simplifies Theme usage

**How**:

Updated the component factory typings to add overloads for components that make use of Theme

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A

