### PR TITLE
chore(typescript): add typing for propsAreCssOverides

### DIFF
--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -109,5 +109,20 @@ test/should-fail.test.tsx(267,15): error TS2345: Argument of type '{ textAlign: 
 test/should-fail.test.tsx(272,18): error TS2345: Argument of type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
   Type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}>)[]'.
     Property 'length' is missing in type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }'.
+test/should-fail.test.tsx(289,35): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & SingleOrA...'.
+  Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & object & SingleOrArray<CSSPropertiesCompleteSingle, \\"left\\" | \\"righ...'.
+    Types of property 'display' are incompatible.
+      Type '\\"blocks\\"' is not assignable to type '\\"none\\" | \\"table\\" | \\"ruby\\" | \\"initial\\" | \\"inherit\\" | \\"unset\\" | \\"block\\" | \\"inline\\" | \\"run-in\\" | \\"fl...'.
+test/should-fail.test.tsx(290,38): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Pick<{ th...'.
+test/should-fail.test.tsx(291,42): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Pick<{ th...'.
+test/should-fail.test.tsx(293,29): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+  Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
+    Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
+      Types of property 'display' are incompatible.
+        Type '\\"blocks\\"' is not assignable to type '\\"none\\" | \\"table\\" | \\"ruby\\" | \\"initial\\" | \\"inherit\\" | \\"unset\\" | \\"block\\" | \\"inline\\" | \\"run-in\\" | \\"fl...'.
+test/should-fail.test.tsx(294,32): error TS2322: Type '{ display: \\"block\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+  Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
+test/should-fail.test.tsx(295,36): error TS2322: Type '{ display: \\"block\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
+  Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
 "
 `;

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -449,4 +449,26 @@ const useWithProps = (
   </div>
 )
 
-// withProps method
+// propsAreCssOverrides
+
+const ComponentPropsAreCssOverides = glamorous(SimpleComponent, {propsAreCssOverrides: true})({
+  margin: 1,
+  fontSize: 1,
+})
+
+const DivPropsAreCssOverides = glamorous('div', {propsAreCssOverrides: true})({
+  margin: 1,
+  fontSize: 1,
+})
+
+
+const usePropsAreCssOverrides = (
+  <div>
+    <ComponentPropsAreCssOverides
+      display={'block'}
+    />
+    <DivPropsAreCssOverides
+      display={'block'}
+    />
+  </div>
+)

--- a/test/should-fail.test.tsx
+++ b/test/should-fail.test.tsx
@@ -273,3 +273,25 @@ glamorous.circle({
   textAlign: "center",
   display: ["flexs", "block"],
 })
+
+// propsAreCssOverrides
+
+const ComponentPropsAreCssOverides = glamorous(SimpleComponent, {propsAreCssOverrides: true})({})
+const ComponentPropsAreNotCssOverides = glamorous(SimpleComponent, {propsAreCssOverrides: false})({})
+const ComponentPropsAreAlsoNotCssOverides = glamorous(SimpleComponent)({})
+
+const DivPropsAreCssOverides = glamorous('div', {propsAreCssOverrides: true})({})
+const DivPropsAreNotCssOverides = glamorous('div', {propsAreCssOverrides: false})({})
+const DivPropsAreAlsoNotCssOverides = glamorous('div')({})
+
+const usePropsAreCssOverrides = (
+  <div>
+    <ComponentPropsAreCssOverides display={'blocks'} />
+    <ComponentPropsAreNotCssOverides display={'block'} />
+    <ComponentPropsAreAlsoNotCssOverides display={'block'} />
+
+    <DivPropsAreCssOverides display={'blocks'} />
+    <DivPropsAreNotCssOverides display={'block'} />
+    <DivPropsAreAlsoNotCssOverides display={'block'} />
+  </div>
+)

--- a/typings/component-factory.ts
+++ b/typings/component-factory.ts
@@ -1,35 +1,11 @@
 import { GlamorousComponent } from './glamorous-component'
 import { Omit } from './helpers'
-/**
- * StyleObject is an objects of Style Properties.
- *
- * @see {@link https://github.com/paypal/glamorous/blob/master/src/create-glamorous.js#L28-L131}
- */
 
-export interface StyleFunction<Properties, Props> {
-  (props: Props):
-    | Partial<Properties>
-    | string
-    | Array<
-      | Partial<Properties>
-      | string
-      | StyleFunction<Properties, Props>
-    >
-}
+import { StyleArgument } from './style-arguments'
 
-export type StyleArray<Properties, Props> = Array<
-  | Partial<Properties>
-  | string
-  | StyleFunction<Properties, Props>
->
+// # built-in DOM - component factories glamorous.div
 
-export type StyleArgument<Properties, Props> =
-  | Partial<Properties>
-  | string
-  | StyleFunction<Properties, Props>
-  | StyleArray<Properties, Props>
-
-// glamorous.div: without Theme
+// * without Theme
 export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
   <Props>(
     ...styles: StyleArgument<Properties, Props>[]
@@ -39,7 +15,7 @@ export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
   >;
 }
 
-// glamorous.div: with Theme
+// * with Theme
 export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
   <Props extends { theme: any }>(
     ...styles: StyleArgument<Properties, Props>[]
@@ -49,7 +25,11 @@ export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
   >;
 }
 
-// glamorous('div'): without Theme
+// # dom tag - component factories glamorous('div')
+
+// ## without propsAreCssOverides
+
+// * without Theme
 export interface KeyGlamorousComponentFactory<ElementProps, Properties, ExternalProps, DefaultProps> {
   <Props>(
     ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
@@ -60,17 +40,43 @@ export interface KeyGlamorousComponentFactory<ElementProps, Properties, External
 }
 
 
-// glamorous('div'): with Theme
+// * with Theme
 export interface KeyGlamorousComponentFactory<ElementProps, Properties, ExternalProps, DefaultProps> {
   <Props extends { theme?: any }>(
     ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
   ): GlamorousComponent<
-    ElementProps & ExternalProps & Partial<DefaultProps> & Omit<Props, 'theme'>,
+    ElementProps & ExternalProps & Partial<DefaultProps> & Omit<Props, 'theme'> & Props,
     ExternalProps
   >;
 }
 
-// glamorous(Component): without Theme
+// ## with propsAreCssOverides
+
+// * without Theme
+export interface KeyGlamorousComponentFactoryCssOverides<ElementProps, Properties, ExternalProps, DefaultProps> {
+  <Props>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
+  ): GlamorousComponent<
+    ElementProps & ExternalProps & Partial<DefaultProps> & Props & Properties,
+    ExternalProps
+  >;
+}
+
+// * with Theme
+export interface KeyGlamorousComponentFactoryCssOverides<ElementProps, Properties, ExternalProps, DefaultProps> {
+  <Props extends { theme?: any }>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
+  ): GlamorousComponent<
+    ElementProps & ExternalProps & Partial<DefaultProps> & Omit<Props, 'theme'> & Properties,
+    ExternalProps
+  >;
+}
+
+// # react component - component factories glamorous(Component)
+
+// ## without propsAreCssOverides
+
+// * without Theme
 export interface GlamorousComponentFactory<ExternalProps, Properties, DefaultProps> {
   <Props>(
     ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
@@ -80,7 +86,7 @@ export interface GlamorousComponentFactory<ExternalProps, Properties, DefaultPro
   >;
 }
 
-// glamorous(Component): with Theme
+// * with Theme
 export interface GlamorousComponentFactory<ExternalProps, Properties, DefaultProps> {
   <Props extends { theme: any }>(
     ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
@@ -88,4 +94,26 @@ export interface GlamorousComponentFactory<ExternalProps, Properties, DefaultPro
     ExternalProps & Partial<DefaultProps> & Omit<Props, 'theme'>,
     Props
   >;
+}
+
+// ## with propsAreCssOverides
+
+// * without Theme
+export interface GlamorousComponentFactoryCssOverides<ExternalProps, Properties, DefaultProps> {
+  <Props>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
+  ): GlamorousComponent<
+    ExternalProps & Partial<DefaultProps> & Properties,
+    Props
+  >
+}
+
+// * with Theme
+export interface GlamorousComponentFactoryCssOverides<ExternalProps, Properties, DefaultProps> {
+  <Props extends { theme: any }>(
+    ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
+  ): GlamorousComponent<
+    ExternalProps & Partial<DefaultProps> & Properties,
+    Props
+  >
 }

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -16,16 +16,19 @@ import {
   WithProps,
 } from './glamorous-component'
 import {
-  StyleFunction,
-  StyleArray,
-  StyleArgument,
-
   BuiltInGlamorousComponentFactory,
   KeyGlamorousComponentFactory,
+  KeyGlamorousComponentFactoryCssOverides,
   GlamorousComponentFactory,
+  GlamorousComponentFactoryCssOverides,
 } from './component-factory'
 import { CSSProperties, CSSPropertiesPseudo, CSSPropertiesLossy } from './css-properties'
 import { SVGProperties, SVGPropertiesLossy } from './svg-properties'
+import {
+  StyleFunction,
+  StyleArray,
+  StyleArgument,
+} from './style-arguments'
 
 import { Omit } from './helpers'
 
@@ -47,7 +50,9 @@ export {
 
   BuiltInGlamorousComponentFactory,
   KeyGlamorousComponentFactory,
+  KeyGlamorousComponentFactoryCssOverides,
   GlamorousComponentFactory,
+  GlamorousComponentFactoryCssOverides,
 
   HTMLComponentFactory,
   HTMLKey,
@@ -61,7 +66,18 @@ export interface GlamorousOptions<Props, Context, DefaultProps> {
   forwardProps: String[]
   shouldClassNameUpdate:
     (props: Props, prevProps: Props, context: Context, prevContext: Context) => boolean
+  propsAreCssOverrides?: false
   withProps: DefaultProps
+}
+
+export interface PropsAreCssOverridesGlamorousOptions<Props, Context, DefaultProps> {
+  displayName?: string
+  rootEl?: string | Element
+  forwardProps?: String[]
+  shouldClassNameUpdate?:
+    (props: Props, prevProps: Props, context: Context, prevContext: Context) => boolean
+  propsAreCssOverrides: true
+  withProps?: DefaultProps
 }
 
 export type Component<T> = React.ComponentClass<T> | React.StatelessComponent<T>
@@ -74,17 +90,32 @@ type OmitInternals<
 type GlamorousProps = { className?: string, theme?: object }
 
 export interface GlamorousInterface extends HTMLComponentFactory, SVGComponentFactory {
-  // This overload is needed due to a union return of CSSProperties | SVGProperties
+  // # Glamarous Component factories
+  
+  // Two overloads are needed per shape due to a union return of CSSProperties | SVGProperties
   // resulting in a loss of typesafety on function arguments
+
+  // ## create a component factory from your own component
+  
   <ExternalProps, Context = object, DefaultProps extends object = object>(
     component: Component<ExternalProps & GlamorousProps>,
     options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
   ): GlamorousComponentFactory<ExternalProps, CSSProperties, DefaultProps>
-
   <ExternalProps, Context = object, DefaultProps extends object = object>(
     component: Component<ExternalProps & GlamorousProps>,
     options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
   ): GlamorousComponentFactory<ExternalProps, SVGProperties, DefaultProps>
+
+  <ExternalProps, Context = object, DefaultProps extends object = object>(
+    component: Component<ExternalProps & GlamorousProps>,
+    options?: PropsAreCssOverridesGlamorousOptions<ExternalProps, Context, DefaultProps>,
+  ): GlamorousComponentFactoryCssOverides<ExternalProps, CSSProperties, DefaultProps>
+  <ExternalProps, Context = object, DefaultProps extends object = object>(
+    component: Component<ExternalProps & GlamorousProps>,
+    options?: PropsAreCssOverridesGlamorousOptions<ExternalProps, Context, DefaultProps>,
+  ): GlamorousComponentFactoryCssOverides<ExternalProps, SVGProperties, DefaultProps>
+
+  // ## create a component factory from a dom tag
 
   <ExternalProps, Context = object, DefaultProps extends object = object>(
     component: HTMLKey,
@@ -92,11 +123,23 @@ export interface GlamorousInterface extends HTMLComponentFactory, SVGComponentFa
   ): KeyGlamorousComponentFactory<
     HTMLComponentFactory[HTMLKey], CSSProperties, ExternalProps, DefaultProps
   >
-
   <ExternalProps, Context = object, DefaultProps extends object = object>(
     component: SVGKey,
     options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
   ): KeyGlamorousComponentFactory<
+    SVGComponentFactory[SVGKey], SVGProperties, ExternalProps, DefaultProps
+  >
+
+  <ExternalProps, Context = object, DefaultProps extends object = object>(
+    component: HTMLKey,
+    options?: PropsAreCssOverridesGlamorousOptions<ExternalProps, Context, DefaultProps>,
+  ): KeyGlamorousComponentFactoryCssOverides<
+    HTMLComponentFactory[HTMLKey], CSSProperties, ExternalProps, DefaultProps
+  >
+  <ExternalProps, Context = object, DefaultProps extends object = object>(
+    component: SVGKey,
+    options?: PropsAreCssOverridesGlamorousOptions<ExternalProps, Context, DefaultProps>,
+  ): KeyGlamorousComponentFactoryCssOverides<
     SVGComponentFactory[SVGKey], SVGProperties, ExternalProps, DefaultProps
   >
 

--- a/typings/style-arguments.d.ts
+++ b/typings/style-arguments.d.ts
@@ -1,0 +1,22 @@
+export interface StyleFunction<Properties, Props> {
+  (props: Props):
+    | Partial<Properties>
+    | string
+    | Array<
+      | Partial<Properties>
+      | string
+      | StyleFunction<Properties, Props>
+    >
+}
+
+export type StyleArray<Properties, Props> = Array<
+  | Partial<Properties>
+  | string
+  | StyleFunction<Properties, Props>
+>
+
+export type StyleArgument<Properties, Props> =
+  | Partial<Properties>
+  | string
+  | StyleFunction<Properties, Props>
+  | StyleArray<Properties, Props>


### PR DESCRIPTION
**What and Why**:
Adds typing for https://github.com/paypal/glamorous/pull/258/files

**How**:

Added overloads to the glamorous interface to use a glamorous component factory typing which adds the Properties on the external when `propsAreCssOverides` is enabled.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
