### PR TITLE
fix(typescript): property nesting beyond one level

### DIFF
--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -15,6 +15,24 @@ const Static = glamorous.div({
   "textAlign": "center",
 });
 
+// multi level nested properties
+
+glamorous.div({
+  ':hover': {
+    '& .vendor-class': {
+      height: '10px',
+    }
+  }
+})
+
+glamorous.svg({
+  ':hover': {
+    '& .vendor-class': {
+      height: '10px',
+    }
+  }
+})
+
 export interface StaticProps {
   visible: boolean
 }

--- a/typings/css-properties.d.ts
+++ b/typings/css-properties.d.ts
@@ -1556,6 +1556,7 @@ export interface CSSPropertiesLossy {
   [propertyName: string]:
     | string | number | CSSPropertiesComplete | undefined
     | Array<CSSPropertiesComplete[keyof CSSPropertiesComplete]>
+    | CSSPropertiesLossy
 }
 
 type CSSProperties =

--- a/typings/svg-properties.d.ts
+++ b/typings/svg-properties.d.ts
@@ -286,6 +286,7 @@ export interface SVGPropertiesLossy {
   [propertyName: string]:
     | string | number | SVGProperties | undefined
     | Array<SVGPropertiesCompleteSingle[keyof SVGPropertiesCompleteSingle]>
+    | SVGPropertiesLossy
 }
 
 type SVGProperties =


### PR DESCRIPTION
**What and Why**:
Fixs a typing issue with style objects which prevented multi level nested keys, also added tests to prevent breaking again in future.

ie
```js
{
  ':hover': {
    '& .vendor-class': {
      height: '10px',
    }
  }
}
```
**How**:

Added `PropertiesLossy` (the string indexer that is used to allow these keys) as an acceptable type for itself.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
