### PR TITLE
chore(typescript): re export all css and svg types

### DIFF
--- a/test/glamorous-exports.test.ts
+++ b/test/glamorous-exports.test.ts
@@ -1,15 +1,24 @@
 import {
   CSSProperties,
+  CSSPropertiesCompleteSingle, CSSPropertiesComplete, CSSPropertiesPseudo, CSSPropertiesLossy,
   SVGProperties,
+  SVGPropertiesCompleteSingle, SVGPropertiesComplete, SVGPropertiesLossy,
 
   GlamorousComponent,
   ExtraGlamorousProps,
+  WithComponent,
+  WithProps,
 
   StyleFunction,
   StyleArray,
   StyleArgument,
+
+  BuiltInGlamorousComponentFactory,
+  KeyGlamorousComponentFactory,
   GlamorousComponentFactory,
 
   HTMLComponentFactory,
+  HTMLKey,
   SVGComponentFactory,
+  SVGKey,
 } from '../'

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -24,17 +24,22 @@ import {
   KeyGlamorousComponentFactory,
   GlamorousComponentFactory,
 } from './component-factory'
-import { CSSProperties, CSSPropertiesPseudo, CSSPropertiesLossy } from './css-properties'
-import { SVGProperties, SVGPropertiesLossy } from './svg-properties'
+import {
+  CSSProperties,
+  CSSPropertiesCompleteSingle, CSSPropertiesComplete, CSSPropertiesPseudo, CSSPropertiesLossy,
+} from './css-properties'
+import {
+  SVGProperties,
+  SVGPropertiesCompleteSingle, SVGPropertiesComplete, SVGPropertiesLossy,
+} from './svg-properties'
 
 import { Omit } from './helpers'
 
 export {
   CSSProperties,
-  CSSPropertiesPseudo,
-  CSSPropertiesLossy,
+  CSSPropertiesCompleteSingle, CSSPropertiesComplete, CSSPropertiesPseudo, CSSPropertiesLossy,
   SVGProperties,
-  SVGPropertiesLossy,
+  SVGPropertiesCompleteSingle, SVGPropertiesComplete, SVGPropertiesLossy,
 
   GlamorousComponent,
   ExtraGlamorousProps,


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Re export all css and svg types from the main definition file.

**Why**:

It's often quite handy to use these when setting up helper methods.

ie.
```ts
import { CSSPropertiesComplete } from 'glamorous'

type GetExecutionStyles = (execution: 'execution-one' | 'execution-two') =>
    CSSPropertiesComplete

const getExecutionStyles: GetExecutionStyles = (execution) => {
    // ... build up a styles object which returns CSSPropertiesComplete
    return styles
}

glamorous('div')(
    getExecutionStyles('execution-one')
)
```
<!-- How were these changes implemented? -->
**How**:

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests 
- [x] Ready to be merged

