### PR TITLE
fix(typescript): fix missing props on glamorous components

### DIFF
--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -173,12 +173,22 @@ interface DividerInsideDividerProps {
 
 // component styles
 const DividerInsideDivider = glamorous(Divider)<{
+  visible: boolean
+}>(
+  ({visible}) => ({
+    display: visible ? 'block' : 'none',
+  })
+);
+
+const DividerInsideDividerWithTheme = glamorous(Divider)<{
+  visible: boolean
   theme: { main: { color: string } }
 }>(
   {
     "fontSize": "10px",
   },
-  ({theme}) => ({
+  ({visible, theme}) => ({
+    display: visible ? 'block' : 'none',
     "color": theme.main.color,
   }),
 );
@@ -194,14 +204,19 @@ export const Balloon = () => (
     <Divider theme={{
       main: { color: "blue" }
     }}>
-      <DividerInsideDivider theme={{
-        main: { color: "blue" }
-      }}>
+      <DividerInsideDivider visible />
+      <DividerInsideDividerWithTheme visible />
+      <DividerInsideDividerWithTheme
+        visible
+        theme={{
+          main: { color: "blue" }
+        }}
+      >
         <Static>Static</Static>
         <StyleFunction color="blue">
           Hello
         </StyleFunction>
-      </DividerInsideDivider>
+      </DividerInsideDividerWithTheme>
     </Divider>
   </ThemeProvider>
 );

--- a/typings/component-factory.ts
+++ b/typings/component-factory.ts
@@ -81,7 +81,7 @@ export interface GlamorousComponentFactory<ExternalProps, Properties, DefaultPro
   <Props>(
     ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
   ): GlamorousComponent<
-    ExternalProps & Partial<DefaultProps>,
+    ExternalProps & Partial<DefaultProps> & Props,
     Props
   >;
 }
@@ -103,7 +103,7 @@ export interface GlamorousComponentFactoryCssOverides<ExternalProps, Properties,
   <Props>(
     ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
   ): GlamorousComponent<
-    ExternalProps & Partial<DefaultProps> & Properties,
+    ExternalProps & Partial<DefaultProps> & Properties & Props,
     Props
   >
 }
@@ -113,7 +113,7 @@ export interface GlamorousComponentFactoryCssOverides<ExternalProps, Properties,
   <Props extends { theme: any }>(
     ...styles: StyleArgument<Properties, Props & ExternalProps & DefaultProps>[]
   ): GlamorousComponent<
-    ExternalProps & Partial<DefaultProps> & Properties,
+    ExternalProps & Partial<DefaultProps> & Properties & Omit<Props, 'theme'>,
     Props
   >
 }


### PR DESCRIPTION
**What**:

Props passed to glamorous component factories were not being set as external props on some glamorous components.

**Why**:

Because it was broken.

**How**:

Pass these props to the Glamorous Component which adds them to the external props intersection type.

**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
