### PR TITLE
fix(withComponent): maintain component properties

### DIFF
--- a/src/__tests__/create-glamorous.with-component.js
+++ b/src/__tests__/create-glamorous.with-component.js
@@ -38,9 +38,13 @@ test('forwardProps can be overridden for the new component', () => {
 })
 
 test('forwards options', () => {
-  const Text = glamorous.span({color: 'red', fontSize: 20})
+  const propsToApply = {id: 'my-span', faded: true}
+  const Text = glamorous
+    .span({color: 'red', fontSize: 20})
+    .withProps(propsToApply)
   const View = Text.withComponent('div', {displayName: 'View'})
   expect(View.displayName).toBe('View')
+  expect(View.propsToApply).toEqual([propsToApply])
 })
 
 test('resulting component can have its styles extended further', () => {

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -98,10 +98,18 @@ function createGlamorous(splitProps) {
       }
 
       function withComponent(newComp, options = {}) {
-        return glamorous(newComp, {
-          forwardProps: GlamorousComponent.forwardProps,
-          ...options,
-        })(GlamorousComponent.styles)
+        const {forwardProps: fp, ...componentProperties} = GlamorousComponent
+        return glamorous(
+          {
+            ...componentProperties,
+            comp: newComp,
+          },
+          {
+            // allows the forwardProps to be overridden
+            forwardProps: fp,
+            ...options,
+          },
+        )(GlamorousComponent.styles)
       }
 
       function withProps(...propsToApply) {


### PR DESCRIPTION
**What**: This forwards _all_ properties from the subject component to
the newly created component.

**Why**: To ensure that the new component is basically everything that
the old one was except a new target component to render.

**How**: Spreading component properties.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

I'd really appreciate a review from at least one person on this. The impact is any time you call `.withComponent` it should do what you probably thought it already did. But we _are_ changing behavior here slightly so I'd like to get this reviewed.

My use case was:

```javascript
const FadedText = Text.withProps({fadedExtra: true})
const Description = glamorous(FadedText)({
  margin: '0 0 10px',
}).withComponent('p')
```

The `propsToApply` of `{fadedExtra: true}` was not getting applied to the component returned from `withComponent`. I've verified that this fixes that.