### PR TITLE
feat(withConfig): add (undocumented) `withConfig` for tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "rules": {
       "import/prefer-default-export": 0,
       "react/no-unused-prop-types": 0,
-      "valid-jsdoc": 0
+      "valid-jsdoc": 0,
+      "func-style": 0
     }
   },
   "lint-staged": {

--- a/src/__tests__/.eslintrc
+++ b/src/__tests__/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "react/prop-types": "off"
+  }
+}

--- a/src/__tests__/index.with-config.js
+++ b/src/__tests__/index.with-config.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import glamorous from '../'
+
+test('withConfig returns a glamorous component with the new config', () => {
+  const config = {
+    displayName: 'MyDiv',
+    propsAreCssOverrides: true,
+  }
+  const styles = {a: 'b'}
+  const MyDiv = glamorous.strong.withConfig(config)(styles)
+  expect(ownProps(MyDiv)).toMatchObject({
+    ...config,
+    comp: 'strong',
+    rootEl: 'strong',
+    forwardProps: [],
+    isGlamorousComponent: true,
+    propsToApply: [],
+    styles: [styles],
+  })
+})
+
+test('withConfig works for non-built-in components', () => {
+  const config = {
+    displayName: 'MyDiv',
+    propsAreCssOverrides: true,
+  }
+  const MyComp = ({shouldRender, ...props}) =>
+    (shouldRender ? <div {...props} /> : null)
+  const styles = {a: 'b'}
+  const forwardProps = ['shouldRender']
+  const MyDiv = glamorous(MyComp, {rootEl: 'div', forwardProps}).withConfig(
+    config,
+  )(styles)
+  expect(ownProps(MyDiv)).toMatchObject({
+    ...config,
+    comp: MyComp,
+    rootEl: 'div',
+    forwardProps,
+    isGlamorousComponent: true,
+    propsToApply: [],
+    styles: [styles],
+  })
+})
+
+function ownProps(thing) {
+  return Reflect.ownKeys(thing).reduce((o, k) => {
+    o[k] = thing[k]
+    return o
+  }, {})
+}

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -23,18 +23,21 @@ function createGlamorous(splitProps) {
   * @param {Object} options helpful info for the GlamorousComponents
   * @return {Function} the glamorousComponentFactory
   */
-  function glamorous(
-    comp,
-    {
+  function glamorous(comp, config = {}) {
+    const {
       rootEl,
       displayName,
       shouldClassNameUpdate,
       forwardProps = [],
       propsAreCssOverrides = comp.propsAreCssOverrides,
       withProps: basePropsToApply,
-    } = {},
-  ) {
+    } = config
+    Object.assign(glamorousComponentFactory, {withConfig})
     return glamorousComponentFactory
+
+    function withConfig(newConfig) {
+      return glamorous(comp, {...config, ...newConfig})
+    }
 
     /**
      * This returns a React Component that renders the comp (closure)
@@ -109,7 +112,7 @@ function createGlamorous(splitProps) {
             forwardProps: fp,
             ...options,
           },
-        )(GlamorousComponent.styles)
+        )()
       }
 
       function withProps(...propsToApply) {
@@ -151,10 +154,11 @@ function createGlamorous(splitProps) {
           propsToApply: basePropsToApply,
         }),
         {
-          withComponent,
           isGlamorousComponent: true,
           propsAreCssOverrides,
+          withComponent,
           withProps,
+          withConfig,
         },
       )
       return GlamorousComponent


### PR DESCRIPTION
I noticed that
[the styled-components babel plugin](https://github.com/styled-components/babel-plugin-styled-components/blob/37a13e9c21c52148ce6e403100df54c0b1561a88/src/visitors/displayNameAndId.js)
sets the `displayName` by using a `withConfig` function and I thought
that was a pretty good idea. So I'm adding this as an undocumented
feature (because I don't think people will really need to use it outside
the babel plugin)

<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
