### PR TITLE
chore(typescript): improve typescript dx

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "tslint": "^5.4.3",
     "tslint-microsoft-contrib": "^5.0.0",
     "tsutils": "^1.9.1",
-    "typescript": "^2.4.2"
+    "typescript": "2.4.2"
   },
   "eslintConfig": {
     "extends": [

--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -42,25 +42,25 @@ test/should-fail.test.tsx(119,3): error TS2345: Argument of type 'StatelessCompo
 test/should-fail.test.tsx(134,3): error TS2345: Argument of type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { theme: any; } & ExampleComponentProps & object>'.
   Type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, { theme: any; } & ExampleComponentProps & ...'.
     Property 'push' is missing in type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }'.
-test/should-fail.test.tsx(135,20): error TS2551: Property 'visibles' does not exist on type '{ theme: any; } & ExampleComponentProps & object'. Did you mean 'visible'?
+test/should-fail.test.tsx(135,20): error TS2339: Property 'visibles' does not exist on type '{ theme: any; } & ExampleComponentProps & object'.
 test/should-fail.test.tsx(140,3): error TS2345: Argument of type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object>'.
   Type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, { visible: boolean; } & object>)[]'.
     Property 'push' is missing in type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }'.
-test/should-fail.test.tsx(150,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
-  Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object>'.
+test/should-fail.test.tsx(150,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExampleComponentProps & object & ExtraGl...'.
+  Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExampleComponentProps & object & ExtraGlamorousProps>'.
     Types of property 'visible' are incompatible.
       Type '\\"string\\"' is not assignable to type 'boolean'.
-test/should-fail.test.tsx(151,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
-  Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object>'.
+test/should-fail.test.tsx(151,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExampleComponentProps & object & ExtraGl...'.
+  Type '{}' is not assignable to type 'Readonly<ExampleComponentProps & object & ExtraGlamorousProps>'.
     Property 'visible' is missing in type '{}'.
-test/should-fail.test.tsx(152,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
-  Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
-    Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
+test/should-fail.test.tsx(152,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
+  Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
+    Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSProperties> & { visible...'.
       Types of property 'visible' are incompatible.
         Type '\\"string\\"' is not assignable to type 'boolean'.
-test/should-fail.test.tsx(153,5): error TS2322: Type '{}' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
-  Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
-    Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
+test/should-fail.test.tsx(153,5): error TS2322: Type '{}' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
+  Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
+    Type '{}' is not assignable to type 'Readonly<BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSProperties> & { visible...'.
       Property 'visible' is missing in type '{}'.
 test/should-fail.test.tsx(157,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, object & {}>'.
   Type '{ allowReorder: false; }' is not assignable to type '(string | SVGProperties | StyleFunction<SVGProperties, object & {}>)[]'.
@@ -86,21 +86,21 @@ test/should-fail.test.tsx(224,3): error TS2345: Argument of type '(props: { visi
 test/should-fail.test.tsx(229,1): error TS2554: Expected 1 arguments, but got 0.
 test/should-fail.test.tsx(230,30): error TS2345: Argument of type '\\"\\"' is not assignable to parameter of type 'object'.
 test/should-fail.test.tsx(231,30): error TS2345: Argument of type 'false' is not assignable to parameter of type 'object'.
-test/should-fail.test.tsx(257,19): error TS2322: Type '{ d: \\"\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
-  Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
-test/should-fail.test.tsx(258,19): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
-  Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
-    Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
+test/should-fail.test.tsx(257,19): error TS2322: Type '{ d: \\"\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
+  Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
+test/should-fail.test.tsx(258,19): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
+  Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
+    Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSProperties> & Partial<{...'.
       Types of property 'primaryColor' are incompatible.
         Type '1' is not assignable to type 'string | undefined'.
-test/should-fail.test.tsx(259,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
-test/should-fail.test.tsx(260,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & Partial<{ primaryC...'.
-  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & Partial<{ primaryColor: string; }> & Pick<{ theme: any; }, never>>'.
+test/should-fail.test.tsx(259,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<Partial<{ primaryColor: string; }> & Pic...'.
+test/should-fail.test.tsx(260,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<Partial<{ primaryColor: string; }> & Pic...'.
+  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<Partial<{ primaryColor: string; }> & Pick<{ theme: any; }, never> & ExtraGlamorousProps>'.
     Types of property 'primaryColor' are incompatible.
       Type '1' is not assignable to type 'string | undefined'.
-test/should-fail.test.tsx(261,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
-test/should-fail.test.tsx(262,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & Partial<{...'.
-  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<ExtraGlamorousProps & object & Partial<{ primaryColor: string; }>>'.
+test/should-fail.test.tsx(261,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<object & Partial<{ primaryColor: string;...'.
+test/should-fail.test.tsx(262,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<object & Partial<{ primaryColor: string;...'.
+  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<object & Partial<{ primaryColor: string; }> & ExtraGlamorousProps>'.
     Types of property 'primaryColor' are incompatible.
       Type '1' is not assignable to type 'string | undefined'.
 test/should-fail.test.tsx(267,15): error TS2345: Argument of type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
@@ -109,20 +109,20 @@ test/should-fail.test.tsx(267,15): error TS2345: Argument of type '{ textAlign: 
 test/should-fail.test.tsx(272,18): error TS2345: Argument of type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
   Type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | SVGProperties | StyleFunction<SVGProperties, {}>)[]'.
     Property 'length' is missing in type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }'.
-test/should-fail.test.tsx(289,35): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & CSSProper...'.
-  Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & object & CSSProperties>'.
+test/should-fail.test.tsx(289,35): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<object & CSSProperties & ExtraGlamorousP...'.
+  Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<object & CSSProperties & ExtraGlamorousProps>'.
     Types of property 'display' are incompatible.
       Type '\\"blocks\\"' is not assignable to type '\\"none\\" | \\"table\\" | \\"ruby\\" | \\"initial\\" | \\"inherit\\" | \\"unset\\" | \\"block\\" | \\"inline\\" | \\"run-in\\" | \\"fl...'.
-test/should-fail.test.tsx(290,38): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object, ComponentS...'.
-test/should-fail.test.tsx(291,42): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object, ComponentS...'.
-test/should-fail.test.tsx(293,29): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
-  Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
-    Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
+test/should-fail.test.tsx(290,38): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<object & ExtraGlamorousProps, ComponentS...'.
+test/should-fail.test.tsx(291,42): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<object & ExtraGlamorousProps, ComponentS...'.
+test/should-fail.test.tsx(293,29): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
+  Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
+    Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSProperties> & object & ...'.
       Types of property 'display' are incompatible.
         Type '\\"blocks\\"' is not assignable to type '\\"none\\" | \\"table\\" | \\"ruby\\" | \\"initial\\" | \\"inherit\\" | \\"unset\\" | \\"block\\" | \\"inline\\" | \\"run-in\\" | \\"fl...'.
-test/should-fail.test.tsx(294,32): error TS2322: Type '{ display: \\"block\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
-  Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
-test/should-fail.test.tsx(295,36): error TS2322: Type '{ display: \\"block\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorous...'.
-  Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(ExtraGlamorousProps & BuiltInGlamorousC...'.
+test/should-fail.test.tsx(294,32): error TS2322: Type '{ display: \\"block\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
+  Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
+test/should-fail.test.tsx(295,36): error TS2322: Type '{ display: \\"block\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
+  Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
 "
 `;

--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -2,37 +2,37 @@
 
 exports[`Typescript expected failures 1`] = `
 "test/should-fail.test.tsx(10,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
-  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}>)[]'.
+  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | SVGProperties | StyleFunction<SVGProperties, {}>)[]'.
     Property 'length' is missing in type '{ fillRule: \\"cat\\"; }'.
 test/should-fail.test.tsx(16,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
-  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}>)[]'.
+  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | SVGProperties | StyleFunction<SVGProperties, {}>)[]'.
     Property 'length' is missing in type '{ fillRule: \\"cat\\"; }'.
 test/should-fail.test.tsx(22,3): error TS2345: Argument of type '() => { fillRule: string; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
-  Type '() => { fillRule: string; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}>)[]'.
+  Type '() => { fillRule: string; }' is not assignable to type '(string | SVGProperties | StyleFunction<SVGProperties, {}>)[]'.
     Property 'push' is missing in type '() => { fillRule: string; }'.
 test/should-fail.test.tsx(30,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
-  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
+  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, {}>)[]'.
     Property 'length' is missing in type '{ float: \\"cat\\"; }'.
 test/should-fail.test.tsx(36,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
-  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
+  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, {}>)[]'.
     Property 'length' is missing in type '{ float: \\"cat\\"; }'.
 test/should-fail.test.tsx(42,3): error TS2345: Argument of type '() => { float: string; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
-  Type '() => { float: string; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
+  Type '() => { float: string; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, {}>)[]'.
     Property 'push' is missing in type '() => { float: string; }'.
 test/should-fail.test.tsx(48,3): error TS2345: Argument of type '() => { float: string; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
-  Type '() => { float: string; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
+  Type '() => { float: string; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, {}>)[]'.
     Property 'push' is missing in type '() => { float: string; }'.
 test/should-fail.test.tsx(64,3): error TS2345: Argument of type '{ fillRule: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object>'.
-  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
+  Type '{ fillRule: \\"cat\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
     Property 'length' is missing in type '{ fillRule: \\"cat\\"; }'.
 test/should-fail.test.tsx(70,3): error TS2345: Argument of type '() => { fillRule: string; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object>'.
-  Type '() => { fillRule: string; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
+  Type '() => { fillRule: string; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
     Property 'push' is missing in type '() => { fillRule: string; }'.
 test/should-fail.test.tsx(76,3): error TS2345: Argument of type '{ float: \\"cat\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object>'.
-  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
+  Type '{ float: \\"cat\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
     Property 'length' is missing in type '{ float: \\"cat\\"; }'.
 test/should-fail.test.tsx(82,3): error TS2345: Argument of type '() => { float: string; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, TestComponentProps & object>'.
-  Type '() => { float: string; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
+  Type '() => { float: string; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, TestComponentProps & object>)[]'.
     Property 'push' is missing in type '() => { float: string; }'.
 test/should-fail.test.tsx(100,24): error TS2551: Property 'colors' does not exist on type 'ExampleTheme'. Did you mean 'color'?
 test/should-fail.test.tsx(111,3): error TS2344: Type 'PropsWithoutTheme' does not satisfy the constraint '{ theme: any; }'.
@@ -40,11 +40,11 @@ test/should-fail.test.tsx(111,3): error TS2344: Type 'PropsWithoutTheme' does no
 test/should-fail.test.tsx(119,3): error TS2345: Argument of type 'StatelessComponent<object>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<object>' is not assignable to type '\\"text\\"'.
 test/should-fail.test.tsx(134,3): error TS2345: Argument of type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { theme: any; } & ExampleComponentProps & object>'.
-  Type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { theme: any; } & ExampleComponen...'.
+  Type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, { theme: any; } & ExampleComponentProps & ...'.
     Property 'push' is missing in type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }'.
-test/should-fail.test.tsx(135,20): error TS2339: Property 'visibles' does not exist on type '{ theme: any; } & ExampleComponentProps & object'.
+test/should-fail.test.tsx(135,20): error TS2551: Property 'visibles' does not exist on type '{ theme: any; } & ExampleComponentProps & object'. Did you mean 'visible'?
 test/should-fail.test.tsx(140,3): error TS2345: Argument of type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object>'.
-  Type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; } & object>)[]'.
+  Type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, { visible: boolean; } & object>)[]'.
     Property 'push' is missing in type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }'.
 test/should-fail.test.tsx(150,29): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & ExampleComponentPr...'.
   Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & ExampleComponentProps & object>'.
@@ -63,16 +63,16 @@ test/should-fail.test.tsx(153,5): error TS2322: Type '{}' is not assignable to t
     Type '{}' is not assignable to type 'Readonly<ExtraGlamorousProps & BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSP...'.
       Property 'visible' is missing in type '{}'.
 test/should-fail.test.tsx(157,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, object & {}>'.
-  Type '{ allowReorder: false; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, object & {}>)[]'.
+  Type '{ allowReorder: false; }' is not assignable to type '(string | SVGProperties | StyleFunction<SVGProperties, object & {}>)[]'.
     Property 'length' is missing in type '{ allowReorder: false; }'.
 test/should-fail.test.tsx(158,18): error TS2345: Argument of type '{ color: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, object & {}>'.
-  Type '{ color: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, object & {}>)[]'.
+  Type '{ color: boolean; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, object & {}>)[]'.
     Property 'length' is missing in type '{ color: boolean; }'.
 test/should-fail.test.tsx(162,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
   Type 'StatelessComponent<ExampleComponentProps>' is not assignable to type '\\"text\\"'.
 test/should-fail.test.tsx(163,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
 test/should-fail.test.tsx(169,3): error TS2345: Argument of type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object>'.
-  Type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; } & object>)[]'.
+  Type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, { visible: boolean; } & object>)[]'.
     Property 'push' is missing in type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }'.
 test/should-fail.test.tsx(170,14): error TS2365: Operator '===' cannot be applied to types 'boolean' and '\\"\\"'.
 test/should-fail.test.tsx(184,15): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateProps'. Did you mean 'color'?
@@ -81,7 +81,7 @@ test/should-fail.test.tsx(191,35): error TS2345: Argument of type 'StatelessComp
 test/should-fail.test.tsx(207,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
 test/should-fail.test.tsx(217,11): error TS2345: Argument of type '\\"div\\"' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
 test/should-fail.test.tsx(224,3): error TS2345: Argument of type '(props: { visible: boolean; }) => { primaryColor: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; }>'.
-  Type '(props: { visible: boolean; }) => { primaryColor: boolean; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, { visible: boolean; }>)[]'.
+  Type '(props: { visible: boolean; }) => { primaryColor: boolean; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, { visible: boolean; }>)[]'.
     Property 'push' is missing in type '(props: { visible: boolean; }) => { primaryColor: boolean; }'.
 test/should-fail.test.tsx(229,1): error TS2554: Expected 1 arguments, but got 0.
 test/should-fail.test.tsx(230,30): error TS2345: Argument of type '\\"\\"' is not assignable to parameter of type 'object'.
@@ -104,13 +104,13 @@ test/should-fail.test.tsx(262,31): error TS2322: Type '{ primaryColor: 1; }' is 
     Types of property 'primaryColor' are incompatible.
       Type '1' is not assignable to type 'string | undefined'.
 test/should-fail.test.tsx(267,15): error TS2345: Argument of type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, {}>'.
-  Type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | Partial<CSSProperties> | StyleFunction<CSSProperties, {}>)[]'.
+  Type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, {}>)[]'.
     Property 'length' is missing in type '{ textAlign: \\"center\\"; display: (\\"block\\" | \\"flexs\\")[]; }'.
 test/should-fail.test.tsx(272,18): error TS2345: Argument of type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, {}>'.
-  Type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | Partial<SVGProperties> | StyleFunction<SVGProperties, {}>)[]'.
+  Type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }' is not assignable to type '(string | SVGProperties | StyleFunction<SVGProperties, {}>)[]'.
     Property 'length' is missing in type '{ textAlign: string; display: (\\"block\\" | \\"flexs\\")[]; }'.
-test/should-fail.test.tsx(289,35): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & SingleOrA...'.
-  Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & object & SingleOrArray<CSSPropertiesCompleteSingle, \\"left\\" | \\"righ...'.
+test/should-fail.test.tsx(289,35): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object & CSSProper...'.
+  Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<ExtraGlamorousProps & object & CSSProperties>'.
     Types of property 'display' are incompatible.
       Type '\\"blocks\\"' is not assignable to type '\\"none\\" | \\"table\\" | \\"ruby\\" | \\"initial\\" | \\"inherit\\" | \\"unset\\" | \\"block\\" | \\"inline\\" | \\"run-in\\" | \\"fl...'.
 test/should-fail.test.tsx(290,38): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExtraGlamorousProps & object, ComponentS...'.

--- a/test/glamorous.test.tsx
+++ b/test/glamorous.test.tsx
@@ -5,7 +5,7 @@ import glamorous, {
 
 // Needed if generating definition files
 // https://github.com/Microsoft/TypeScript/issues/5938
-import { ExtraGlamorousProps, GlamorousComponentProps } from "../";
+import { GlamorousComponent, GlamorousComponentProps } from "../";
 
 import { WithComponent, WithProps, CSSPropertiesPseudo, CSSPropertiesLossy } from "../"
 

--- a/typings/built-in-component-factories.d.ts
+++ b/typings/built-in-component-factories.d.ts
@@ -4,154 +4,150 @@ import {
   BuiltInGlamorousComponentFactory,
 } from './component-factory'
 
-export type HTMLGlamorousComponentFactory<
-  HTMLElement,
-  Properties
-> = BuiltInGlamorousComponentFactory<React.HTMLProps<HTMLElement>, Properties>
+export type HTMLGlamorousComponentFactory<HTMLElement> =
+  BuiltInGlamorousComponentFactory<React.HTMLProps<HTMLElement>, CSSProperties>
 
-export type SVGGlamorousComponentFactory<
-  SVGElement,
-  Attributes
-> = BuiltInGlamorousComponentFactory<React.SVGAttributes<SVGElement>, Attributes>
+export type SVGGlamorousComponentFactory<SVGElement> =
+  BuiltInGlamorousComponentFactory<React.SVGAttributes<SVGElement>, SVGProperties>
 
 export interface HTMLComponentFactory {
-  a: HTMLGlamorousComponentFactory<HTMLAnchorElement, CSSProperties>
-  abbr: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  address: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  area: HTMLGlamorousComponentFactory<HTMLAreaElement, CSSProperties>
-  article: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  aside: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  audio: HTMLGlamorousComponentFactory<HTMLAudioElement, CSSProperties>
-  b: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  base: HTMLGlamorousComponentFactory<HTMLBaseElement, CSSProperties>
-  bdi: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  bdo: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  big: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  blockquote: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  body: HTMLGlamorousComponentFactory<HTMLBodyElement, CSSProperties>
-  br: HTMLGlamorousComponentFactory<HTMLBRElement, CSSProperties>
-  button: HTMLGlamorousComponentFactory<HTMLButtonElement, CSSProperties>
-  canvas: HTMLGlamorousComponentFactory<HTMLCanvasElement, CSSProperties>
-  caption: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  cite: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  code: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  col: HTMLGlamorousComponentFactory<HTMLTableColElement, CSSProperties>
-  colgroup: HTMLGlamorousComponentFactory<HTMLTableColElement, CSSProperties>
-  data: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  datalist: HTMLGlamorousComponentFactory<HTMLDataListElement, CSSProperties>
-  dd: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  del: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  details: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  dfn: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  dialog: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  div: HTMLGlamorousComponentFactory<HTMLDivElement, CSSProperties>
-  dl: HTMLGlamorousComponentFactory<HTMLDListElement, CSSProperties>
-  dt: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  em: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  embed: HTMLGlamorousComponentFactory<HTMLEmbedElement, CSSProperties>
-  fieldset: HTMLGlamorousComponentFactory<HTMLFieldSetElement, CSSProperties>
-  figcaption: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  figure: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  footer: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  form: HTMLGlamorousComponentFactory<HTMLFormElement, CSSProperties>
-  h1: HTMLGlamorousComponentFactory<HTMLHeadingElement, CSSProperties>
-  h2: HTMLGlamorousComponentFactory<HTMLHeadingElement, CSSProperties>
-  h3: HTMLGlamorousComponentFactory<HTMLHeadingElement, CSSProperties>
-  h4: HTMLGlamorousComponentFactory<HTMLHeadingElement, CSSProperties>
-  h5: HTMLGlamorousComponentFactory<HTMLHeadingElement, CSSProperties>
-  h6: HTMLGlamorousComponentFactory<HTMLHeadingElement, CSSProperties>
-  head: HTMLGlamorousComponentFactory<HTMLHeadElement, CSSProperties>
-  header: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  hgroup: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  hr: HTMLGlamorousComponentFactory<HTMLHRElement, CSSProperties>
-  html: HTMLGlamorousComponentFactory<HTMLHtmlElement, CSSProperties>
-  i: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  iframe: HTMLGlamorousComponentFactory<HTMLIFrameElement, CSSProperties>
-  img: HTMLGlamorousComponentFactory<HTMLImageElement, CSSProperties>
-  input: HTMLGlamorousComponentFactory<HTMLInputElement, CSSProperties>
-  ins: HTMLGlamorousComponentFactory<HTMLModElement, CSSProperties>
-  kbd: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  keygen: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  label: HTMLGlamorousComponentFactory<HTMLLabelElement, CSSProperties>
-  legend: HTMLGlamorousComponentFactory<HTMLLegendElement, CSSProperties>
-  li: HTMLGlamorousComponentFactory<HTMLLIElement, CSSProperties>
-  link: HTMLGlamorousComponentFactory<HTMLLinkElement, CSSProperties>
-  main: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  map: HTMLGlamorousComponentFactory<HTMLMapElement, CSSProperties>
-  mark: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  menu: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  menuitem: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  meta: HTMLGlamorousComponentFactory<HTMLMetaElement, CSSProperties>
-  meter: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  nav: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  noscript: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  object: HTMLGlamorousComponentFactory<HTMLObjectElement, CSSProperties>
-  ol: HTMLGlamorousComponentFactory<HTMLOListElement, CSSProperties>
-  optgroup: HTMLGlamorousComponentFactory<HTMLOptGroupElement, CSSProperties>
-  option: HTMLGlamorousComponentFactory<HTMLOptionElement, CSSProperties>
-  output: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  p: HTMLGlamorousComponentFactory<HTMLParagraphElement, CSSProperties>
-  param: HTMLGlamorousComponentFactory<HTMLParamElement, CSSProperties>
-  picture: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  pre: HTMLGlamorousComponentFactory<HTMLPreElement, CSSProperties>
-  progress: HTMLGlamorousComponentFactory<HTMLProgressElement, CSSProperties>
-  q: HTMLGlamorousComponentFactory<HTMLQuoteElement, CSSProperties>
-  rp: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  rt: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  ruby: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  s: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  samp: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  script: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  section: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  select: HTMLGlamorousComponentFactory<HTMLSelectElement, CSSProperties>
-  small: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  source: HTMLGlamorousComponentFactory<HTMLSourceElement, CSSProperties>
-  span: HTMLGlamorousComponentFactory<HTMLSpanElement, CSSProperties>
-  strong: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  style: HTMLGlamorousComponentFactory<HTMLStyleElement, CSSProperties>
-  sub: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  summary: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  sup: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  table: HTMLGlamorousComponentFactory<HTMLTableElement, CSSProperties>
-  tbody: HTMLGlamorousComponentFactory<HTMLTableSectionElement, CSSProperties>
-  td: HTMLGlamorousComponentFactory<HTMLTableDataCellElement, CSSProperties>
-  textarea: HTMLGlamorousComponentFactory<HTMLTextAreaElement, CSSProperties>
-  tfoot: HTMLGlamorousComponentFactory<HTMLTableSectionElement, CSSProperties>
-  th: HTMLGlamorousComponentFactory<HTMLTableHeaderCellElement, CSSProperties>
-  thead: HTMLGlamorousComponentFactory<HTMLTableSectionElement, CSSProperties>
-  time: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  title: HTMLGlamorousComponentFactory<HTMLTitleElement, CSSProperties>
-  tr: HTMLGlamorousComponentFactory<HTMLTableRowElement, CSSProperties>
-  track: HTMLGlamorousComponentFactory<HTMLTrackElement, CSSProperties>
-  u: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  ul: HTMLGlamorousComponentFactory<HTMLUListElement, CSSProperties>
-  "var": HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
-  video: HTMLGlamorousComponentFactory<HTMLVideoElement, CSSProperties>
-  wbr: HTMLGlamorousComponentFactory<HTMLElement, CSSProperties>
+  a: HTMLGlamorousComponentFactory<HTMLAnchorElement>
+  abbr: HTMLGlamorousComponentFactory<HTMLElement>
+  address: HTMLGlamorousComponentFactory<HTMLElement>
+  area: HTMLGlamorousComponentFactory<HTMLAreaElement>
+  article: HTMLGlamorousComponentFactory<HTMLElement>
+  aside: HTMLGlamorousComponentFactory<HTMLElement>
+  audio: HTMLGlamorousComponentFactory<HTMLAudioElement>
+  b: HTMLGlamorousComponentFactory<HTMLElement>
+  base: HTMLGlamorousComponentFactory<HTMLBaseElement>
+  bdi: HTMLGlamorousComponentFactory<HTMLElement>
+  bdo: HTMLGlamorousComponentFactory<HTMLElement>
+  big: HTMLGlamorousComponentFactory<HTMLElement>
+  blockquote: HTMLGlamorousComponentFactory<HTMLElement>
+  body: HTMLGlamorousComponentFactory<HTMLBodyElement>
+  br: HTMLGlamorousComponentFactory<HTMLBRElement>
+  button: HTMLGlamorousComponentFactory<HTMLButtonElement>
+  canvas: HTMLGlamorousComponentFactory<HTMLCanvasElement>
+  caption: HTMLGlamorousComponentFactory<HTMLElement>
+  cite: HTMLGlamorousComponentFactory<HTMLElement>
+  code: HTMLGlamorousComponentFactory<HTMLElement>
+  col: HTMLGlamorousComponentFactory<HTMLTableColElement>
+  colgroup: HTMLGlamorousComponentFactory<HTMLTableColElement>
+  data: HTMLGlamorousComponentFactory<HTMLElement>
+  datalist: HTMLGlamorousComponentFactory<HTMLDataListElement>
+  dd: HTMLGlamorousComponentFactory<HTMLElement>
+  del: HTMLGlamorousComponentFactory<HTMLElement>
+  details: HTMLGlamorousComponentFactory<HTMLElement>
+  dfn: HTMLGlamorousComponentFactory<HTMLElement>
+  dialog: HTMLGlamorousComponentFactory<HTMLElement>
+  div: HTMLGlamorousComponentFactory<HTMLDivElement>
+  dl: HTMLGlamorousComponentFactory<HTMLDListElement>
+  dt: HTMLGlamorousComponentFactory<HTMLElement>
+  em: HTMLGlamorousComponentFactory<HTMLElement>
+  embed: HTMLGlamorousComponentFactory<HTMLEmbedElement>
+  fieldset: HTMLGlamorousComponentFactory<HTMLFieldSetElement>
+  figcaption: HTMLGlamorousComponentFactory<HTMLElement>
+  figure: HTMLGlamorousComponentFactory<HTMLElement>
+  footer: HTMLGlamorousComponentFactory<HTMLElement>
+  form: HTMLGlamorousComponentFactory<HTMLFormElement>
+  h1: HTMLGlamorousComponentFactory<HTMLHeadingElement>
+  h2: HTMLGlamorousComponentFactory<HTMLHeadingElement>
+  h3: HTMLGlamorousComponentFactory<HTMLHeadingElement>
+  h4: HTMLGlamorousComponentFactory<HTMLHeadingElement>
+  h5: HTMLGlamorousComponentFactory<HTMLHeadingElement>
+  h6: HTMLGlamorousComponentFactory<HTMLHeadingElement>
+  head: HTMLGlamorousComponentFactory<HTMLHeadElement>
+  header: HTMLGlamorousComponentFactory<HTMLElement>
+  hgroup: HTMLGlamorousComponentFactory<HTMLElement>
+  hr: HTMLGlamorousComponentFactory<HTMLHRElement>
+  html: HTMLGlamorousComponentFactory<HTMLHtmlElement>
+  i: HTMLGlamorousComponentFactory<HTMLElement>
+  iframe: HTMLGlamorousComponentFactory<HTMLIFrameElement>
+  img: HTMLGlamorousComponentFactory<HTMLImageElement>
+  input: HTMLGlamorousComponentFactory<HTMLInputElement>
+  ins: HTMLGlamorousComponentFactory<HTMLModElement>
+  kbd: HTMLGlamorousComponentFactory<HTMLElement>
+  keygen: HTMLGlamorousComponentFactory<HTMLElement>
+  label: HTMLGlamorousComponentFactory<HTMLLabelElement>
+  legend: HTMLGlamorousComponentFactory<HTMLLegendElement>
+  li: HTMLGlamorousComponentFactory<HTMLLIElement>
+  link: HTMLGlamorousComponentFactory<HTMLLinkElement>
+  main: HTMLGlamorousComponentFactory<HTMLElement>
+  map: HTMLGlamorousComponentFactory<HTMLMapElement>
+  mark: HTMLGlamorousComponentFactory<HTMLElement>
+  menu: HTMLGlamorousComponentFactory<HTMLElement>
+  menuitem: HTMLGlamorousComponentFactory<HTMLElement>
+  meta: HTMLGlamorousComponentFactory<HTMLMetaElement>
+  meter: HTMLGlamorousComponentFactory<HTMLElement>
+  nav: HTMLGlamorousComponentFactory<HTMLElement>
+  noscript: HTMLGlamorousComponentFactory<HTMLElement>
+  object: HTMLGlamorousComponentFactory<HTMLObjectElement>
+  ol: HTMLGlamorousComponentFactory<HTMLOListElement>
+  optgroup: HTMLGlamorousComponentFactory<HTMLOptGroupElement>
+  option: HTMLGlamorousComponentFactory<HTMLOptionElement>
+  output: HTMLGlamorousComponentFactory<HTMLElement>
+  p: HTMLGlamorousComponentFactory<HTMLParagraphElement>
+  param: HTMLGlamorousComponentFactory<HTMLParamElement>
+  picture: HTMLGlamorousComponentFactory<HTMLElement>
+  pre: HTMLGlamorousComponentFactory<HTMLPreElement>
+  progress: HTMLGlamorousComponentFactory<HTMLProgressElement>
+  q: HTMLGlamorousComponentFactory<HTMLQuoteElement>
+  rp: HTMLGlamorousComponentFactory<HTMLElement>
+  rt: HTMLGlamorousComponentFactory<HTMLElement>
+  ruby: HTMLGlamorousComponentFactory<HTMLElement>
+  s: HTMLGlamorousComponentFactory<HTMLElement>
+  samp: HTMLGlamorousComponentFactory<HTMLElement>
+  script: HTMLGlamorousComponentFactory<HTMLElement>
+  section: HTMLGlamorousComponentFactory<HTMLElement>
+  select: HTMLGlamorousComponentFactory<HTMLSelectElement>
+  small: HTMLGlamorousComponentFactory<HTMLElement>
+  source: HTMLGlamorousComponentFactory<HTMLSourceElement>
+  span: HTMLGlamorousComponentFactory<HTMLSpanElement>
+  strong: HTMLGlamorousComponentFactory<HTMLElement>
+  style: HTMLGlamorousComponentFactory<HTMLStyleElement>
+  sub: HTMLGlamorousComponentFactory<HTMLElement>
+  summary: HTMLGlamorousComponentFactory<HTMLElement>
+  sup: HTMLGlamorousComponentFactory<HTMLElement>
+  table: HTMLGlamorousComponentFactory<HTMLTableElement>
+  tbody: HTMLGlamorousComponentFactory<HTMLTableSectionElement>
+  td: HTMLGlamorousComponentFactory<HTMLTableDataCellElement>
+  textarea: HTMLGlamorousComponentFactory<HTMLTextAreaElement>
+  tfoot: HTMLGlamorousComponentFactory<HTMLTableSectionElement>
+  th: HTMLGlamorousComponentFactory<HTMLTableHeaderCellElement>
+  thead: HTMLGlamorousComponentFactory<HTMLTableSectionElement>
+  time: HTMLGlamorousComponentFactory<HTMLElement>
+  title: HTMLGlamorousComponentFactory<HTMLTitleElement>
+  tr: HTMLGlamorousComponentFactory<HTMLTableRowElement>
+  track: HTMLGlamorousComponentFactory<HTMLTrackElement>
+  u: HTMLGlamorousComponentFactory<HTMLElement>
+  ul: HTMLGlamorousComponentFactory<HTMLUListElement>
+  "var": HTMLGlamorousComponentFactory<HTMLElement>
+  video: HTMLGlamorousComponentFactory<HTMLVideoElement>
+  wbr: HTMLGlamorousComponentFactory<HTMLElement>
 }
 
 export type HTMLKey = keyof HTMLComponentFactory
 
 export interface SVGComponentFactory {
-  circle: SVGGlamorousComponentFactory<SVGCircleElement, SVGProperties>
-  clipPath: SVGGlamorousComponentFactory<SVGClipPathElement, SVGProperties>
-  defs: SVGGlamorousComponentFactory<SVGDefsElement, SVGProperties>
-  ellipse: SVGGlamorousComponentFactory<SVGEllipseElement, SVGProperties>
-  g: SVGGlamorousComponentFactory<SVGGElement, SVGProperties>
-  image: SVGGlamorousComponentFactory<SVGImageElement, SVGProperties>
-  line: SVGGlamorousComponentFactory<SVGLineElement, SVGProperties>
-  linearGradient: SVGGlamorousComponentFactory<SVGLinearGradientElement, SVGProperties>
-  mask: SVGGlamorousComponentFactory<SVGMaskElement, SVGProperties>
-  path: SVGGlamorousComponentFactory<SVGPathElement, SVGProperties>
-  pattern: SVGGlamorousComponentFactory<SVGPatternElement, SVGProperties>
-  polygon: SVGGlamorousComponentFactory<SVGPolygonElement, SVGProperties>
-  polyline: SVGGlamorousComponentFactory<SVGPolylineElement, SVGProperties>
-  radialGradient: SVGGlamorousComponentFactory<SVGRadialGradientElement, SVGProperties>
-  rect: SVGGlamorousComponentFactory<SVGRectElement, SVGProperties>
-  stop: SVGGlamorousComponentFactory<SVGStopElement, SVGProperties>
-  svg: SVGGlamorousComponentFactory<SVGSVGElement, SVGProperties>
-  text: SVGGlamorousComponentFactory<SVGTextElement, SVGProperties>
-  tspan: SVGGlamorousComponentFactory<SVGTSpanElement, SVGProperties>
+  circle: SVGGlamorousComponentFactory<SVGCircleElement>
+  clipPath: SVGGlamorousComponentFactory<SVGClipPathElement>
+  defs: SVGGlamorousComponentFactory<SVGDefsElement>
+  ellipse: SVGGlamorousComponentFactory<SVGEllipseElement>
+  g: SVGGlamorousComponentFactory<SVGGElement>
+  image: SVGGlamorousComponentFactory<SVGImageElement>
+  line: SVGGlamorousComponentFactory<SVGLineElement>
+  linearGradient: SVGGlamorousComponentFactory<SVGLinearGradientElement>
+  mask: SVGGlamorousComponentFactory<SVGMaskElement>
+  path: SVGGlamorousComponentFactory<SVGPathElement>
+  pattern: SVGGlamorousComponentFactory<SVGPatternElement>
+  polygon: SVGGlamorousComponentFactory<SVGPolygonElement>
+  polyline: SVGGlamorousComponentFactory<SVGPolylineElement>
+  radialGradient: SVGGlamorousComponentFactory<SVGRadialGradientElement>
+  rect: SVGGlamorousComponentFactory<SVGRectElement>
+  stop: SVGGlamorousComponentFactory<SVGStopElement>
+  svg: SVGGlamorousComponentFactory<SVGSVGElement>
+  text: SVGGlamorousComponentFactory<SVGTextElement>
+  tspan: SVGGlamorousComponentFactory<SVGTSpanElement>
 }
 
 export type SVGKey = keyof SVGComponentFactory

--- a/typings/css-properties.d.ts
+++ b/typings/css-properties.d.ts
@@ -1559,7 +1559,8 @@ export interface CSSPropertiesLossy {
     | CSSPropertiesLossy
 }
 
-type CSSProperties =
-  & CSSPropertiesComplete
-  & CSSPropertiesPseudo
-  & CSSPropertiesLossy
+export interface CSSProperties extends
+  CSSPropertiesComplete,
+  CSSPropertiesPseudo,
+  CSSPropertiesLossy
+    {}

--- a/typings/glamorous-component.d.ts
+++ b/typings/glamorous-component.d.ts
@@ -36,10 +36,15 @@ export interface WithProps<ExternalProps, Props> {
   >
 }
 
-export type GlamorousComponent<ExternalProps, Props> =
-  & React.ComponentClass<ExtraGlamorousProps & ExternalProps>
-  & WithComponent<ExternalProps, Props>
-  & WithProps<ExternalProps, Props>
+export interface GlamorousComponentFunctions<ExternalProps, Props> extends 
+  WithComponent<ExternalProps, Props>,
+  WithProps<ExternalProps, Props>
+    {}
+
+export interface GlamorousComponent<ExternalProps, Props> extends
+  React.ComponentClass<ExternalProps & ExtraGlamorousProps>,
+  GlamorousComponentFunctions<ExternalProps, Props>
+    {}
 
 export type GlamorousComponentProps<ExternalProps> =
   & JSX.IntrinsicAttributes
@@ -51,3 +56,4 @@ export type GlamorousComponentProps<ExternalProps> =
   >
   & ExternalProps
   & { children?: React.ReactNode }
+

--- a/typings/style-arguments.d.ts
+++ b/typings/style-arguments.d.ts
@@ -1,32 +1,32 @@
 export interface StyleFunction<Properties, Props> {
   (props: Props):
-    | Partial<Properties>
+    | Properties
     | string
     | Array<
-      | Partial<Properties>
+      | Properties
       | string
       | StyleFunction<Properties, Props>
     >
 }
 
 export type StyleArray<Properties, Props> = Array<
-  | Partial<Properties>
+  | Properties
   | string
   | StyleFunction<Properties, Props>
 >
 
 export type StaticStyleArray<Properties> = Array<
-| Partial<Properties>
-| string
+  | Properties
+  | string
 >
 
 export type StyleArgument<Properties, Props> =
-  | Partial<Properties>
+  | Properties
   | string
   | StyleFunction<Properties, Props>
   | StyleArray<Properties, Props>
 
 export type StaticStyleArgument<Properties> =
-  | Partial<Properties>
+  | Properties
   | string
   | StaticStyleArray<Properties>

--- a/typings/svg-properties.d.ts
+++ b/typings/svg-properties.d.ts
@@ -289,6 +289,7 @@ export interface SVGPropertiesLossy {
     | SVGPropertiesLossy
 }
 
-type SVGProperties =
-  & SVGPropertiesComplete
-  & SVGPropertiesLossy
+export interface SVGProperties extends
+  SVGPropertiesComplete,
+  SVGPropertiesLossy
+    {}


### PR DESCRIPTION
**What**:

Improvements to the typings to give better parameter hints.

**Why**:

The current typings use types in a number of places which results in enormous parameter hints in vscode and online editors using monaco such as codesandbox and stackblitz.

**How**:

Replaced a number of types with interfaces and removed unneeded Partials.

**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
- [ ] Added myself to contributors table N/A

Note:

Converting the `GlamorousComponent` from a type -> interface means that when generating definitions users will now need to re-export `GlamorousComponent` rather than `ExtraGlamorousProps`.

## improved-parameter-hints

![improved-parameter-hints](https://user-images.githubusercontent.com/848525/29612430-d9a2e1c0-8833-11e7-8b24-0ea1b1ee4853.gif)

## old-parameter-hints

![old-parameter-hints](https://user-images.githubusercontent.com/848525/29612238-24a3da72-8833-11e7-9fe0-89e6d6863628.gif)