### PR TITLE
fix(typescript): fix type of component factories created from strings

### DIFF
--- a/src/__tests__/__snapshots__/typescript.js.snap
+++ b/src/__tests__/__snapshots__/typescript.js.snap
@@ -37,8 +37,7 @@ test/should-fail.test.tsx(82,3): error TS2345: Argument of type '() => { float: 
 test/should-fail.test.tsx(100,24): error TS2551: Property 'colors' does not exist on type 'ExampleTheme'. Did you mean 'color'?
 test/should-fail.test.tsx(111,3): error TS2344: Type 'PropsWithoutTheme' does not satisfy the constraint '{ theme: any; }'.
   Property 'theme' is missing in type 'PropsWithoutTheme'.
-test/should-fail.test.tsx(119,3): error TS2345: Argument of type 'StatelessComponent<object>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
-  Type 'StatelessComponent<object>' is not assignable to type '\\"text\\"'.
+test/should-fail.test.tsx(119,3): error TS2345: Argument of type 'StatelessComponent<object>' is not assignable to parameter of type '\\"tspan\\"'.
 test/should-fail.test.tsx(134,3): error TS2345: Argument of type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { theme: any; } & ExampleComponentProps & object>'.
   Type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, { theme: any; } & ExampleComponentProps & ...'.
     Property 'push' is missing in type '(props: { theme: any; } & ExampleComponentProps & object) => { display: \\"none\\" | \\"hidden\\"; }'.
@@ -53,46 +52,40 @@ test/should-fail.test.tsx(150,29): error TS2322: Type '{ visible: \\"string\\"; 
 test/should-fail.test.tsx(151,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<ExampleComponentProps & object & ExtraGl...'.
   Type '{}' is not assignable to type 'Readonly<ExampleComponentProps & object & ExtraGlamorousProps>'.
     Property 'visible' is missing in type '{}'.
-test/should-fail.test.tsx(152,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
-  Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
-    Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSProperties> & { visible...'.
-      Types of property 'visible' are incompatible.
-        Type '\\"string\\"' is not assignable to type 'boolean'.
-test/should-fail.test.tsx(153,5): error TS2322: Type '{}' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
-  Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
-    Type '{}' is not assignable to type 'Readonly<BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSProperties> & { visible...'.
-      Property 'visible' is missing in type '{}'.
+test/should-fail.test.tsx(152,32): error TS2322: Type '{ visible: \\"string\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<HTMLProps<HTMLDivElement> & { visible: b...'.
+  Type '{ visible: \\"string\\"; }' is not assignable to type 'Readonly<HTMLProps<HTMLDivElement> & { visible: boolean; } & object & ExtraGlamorousProps>'.
+    Types of property 'visible' are incompatible.
+      Type '\\"string\\"' is not assignable to type 'boolean'.
+test/should-fail.test.tsx(153,5): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<HTMLProps<HTMLDivElement> & { visible: b...'.
+  Type '{}' is not assignable to type 'Readonly<HTMLProps<HTMLDivElement> & { visible: boolean; } & object & ExtraGlamorousProps>'.
+    Property 'visible' is missing in type '{}'.
 test/should-fail.test.tsx(157,21): error TS2345: Argument of type '{ allowReorder: false; }' is not assignable to parameter of type 'StyleArgument<SVGProperties, object & {}>'.
   Type '{ allowReorder: false; }' is not assignable to type '(string | SVGProperties | StyleFunction<SVGProperties, object & {}>)[]'.
     Property 'length' is missing in type '{ allowReorder: false; }'.
 test/should-fail.test.tsx(158,18): error TS2345: Argument of type '{ color: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, object & {}>'.
   Type '{ color: boolean; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, object & {}>)[]'.
     Property 'length' is missing in type '{ color: boolean; }'.
-test/should-fail.test.tsx(162,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
-  Type 'StatelessComponent<ExampleComponentProps>' is not assignable to type '\\"text\\"'.
+test/should-fail.test.tsx(162,4): error TS2345: Argument of type 'StatelessComponent<ExampleComponentProps>' is not assignable to parameter of type '\\"tspan\\"'.
 test/should-fail.test.tsx(163,4): error TS7006: Parameter 'props' implicitly has an 'any' type.
 test/should-fail.test.tsx(169,3): error TS2345: Argument of type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; } & object>'.
   Type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, { visible: boolean; } & object>)[]'.
     Property 'push' is missing in type '(props: { visible: boolean; } & object) => { display: \\"none\\" | \\"hidden\\"; }'.
 test/should-fail.test.tsx(170,14): error TS2365: Operator '===' cannot be applied to types 'boolean' and '\\"\\"'.
 test/should-fail.test.tsx(184,15): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateProps'. Did you mean 'color'?
-test/should-fail.test.tsx(191,35): error TS2345: Argument of type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
-  Type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to type '\\"text\\"'.
+test/should-fail.test.tsx(191,35): error TS2345: Argument of type 'StatelessComponent<ShouldClassNameUpdateProps>' is not assignable to parameter of type '\\"tspan\\"'.
 test/should-fail.test.tsx(207,17): error TS2551: Property 'colors' does not exist on type 'ShouldClassNameUpdateContext'. Did you mean 'color'?
-test/should-fail.test.tsx(217,11): error TS2345: Argument of type '\\"div\\"' is not assignable to parameter of type '\\"circle\\" | \\"clipPath\\" | \\"defs\\" | \\"ellipse\\" | \\"g\\" | \\"image\\" | \\"line\\" | \\"linearGradient\\" | \\"mask\\" |...'.
+test/should-fail.test.tsx(217,11): error TS2345: Argument of type '\\"div\\"' is not assignable to parameter of type '\\"tspan\\"'.
 test/should-fail.test.tsx(224,3): error TS2345: Argument of type '(props: { visible: boolean; }) => { primaryColor: boolean; }' is not assignable to parameter of type 'StyleArgument<CSSProperties, { visible: boolean; }>'.
   Type '(props: { visible: boolean; }) => { primaryColor: boolean; }' is not assignable to type '(string | CSSProperties | StyleFunction<CSSProperties, { visible: boolean; }>)[]'.
     Property 'push' is missing in type '(props: { visible: boolean; }) => { primaryColor: boolean; }'.
 test/should-fail.test.tsx(229,1): error TS2554: Expected 1 arguments, but got 0.
 test/should-fail.test.tsx(230,30): error TS2345: Argument of type '\\"\\"' is not assignable to parameter of type 'object'.
 test/should-fail.test.tsx(231,30): error TS2345: Argument of type 'false' is not assignable to parameter of type 'object'.
-test/should-fail.test.tsx(257,19): error TS2322: Type '{ d: \\"\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
-  Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
-test/should-fail.test.tsx(258,19): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
-  Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
-    Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSProperties> & Partial<{...'.
-      Types of property 'primaryColor' are incompatible.
-        Type '1' is not assignable to type 'string | undefined'.
+test/should-fail.test.tsx(257,19): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<HTMLProps<HTMLDivElement> & Partial<{ pr...'.
+test/should-fail.test.tsx(258,19): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<HTMLProps<HTMLDivElement> & Partial<{ pr...'.
+  Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<HTMLProps<HTMLDivElement> & Partial<{ primaryColor: string; }> & Pick<{ theme?: any; }, ...'.
+    Types of property 'primaryColor' are incompatible.
+      Type '1' is not assignable to type 'string | undefined'.
 test/should-fail.test.tsx(259,31): error TS2559: Type '{ d: \\"\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<Partial<{ primaryColor: string; }> & Pic...'.
 test/should-fail.test.tsx(260,31): error TS2322: Type '{ primaryColor: 1; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<Partial<{ primaryColor: string; }> & Pic...'.
   Type '{ primaryColor: 1; }' is not assignable to type 'Readonly<Partial<{ primaryColor: string; }> & Pick<{ theme: any; }, never> & ExtraGlamorousProps>'.
@@ -115,14 +108,11 @@ test/should-fail.test.tsx(289,35): error TS2322: Type '{ display: \\"blocks\\"; 
       Type '\\"blocks\\"' is not assignable to type '\\"none\\" | \\"table\\" | \\"ruby\\" | \\"initial\\" | \\"inherit\\" | \\"unset\\" | \\"block\\" | \\"inline\\" | \\"run-in\\" | \\"fl...'.
 test/should-fail.test.tsx(290,38): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<object & ExtraGlamorousProps, ComponentS...'.
 test/should-fail.test.tsx(291,42): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<object & ExtraGlamorousProps, ComponentS...'.
-test/should-fail.test.tsx(293,29): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
-  Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
-    Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<BuiltInGlamorousComponentFactory<HTMLProps<HTMLVideoElement>, CSSProperties> & object & ...'.
-      Types of property 'display' are incompatible.
-        Type '\\"blocks\\"' is not assignable to type '\\"none\\" | \\"table\\" | \\"ruby\\" | \\"initial\\" | \\"inherit\\" | \\"unset\\" | \\"block\\" | \\"inline\\" | \\"run-in\\" | \\"fl...'.
-test/should-fail.test.tsx(294,32): error TS2322: Type '{ display: \\"block\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
-  Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
-test/should-fail.test.tsx(295,36): error TS2322: Type '{ display: \\"block\\"; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLP...'.
-  Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<(BuiltInGlamorousComponentFactory<HTMLPr...'.
+test/should-fail.test.tsx(293,29): error TS2322: Type '{ display: \\"blocks\\"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<HTMLProps<HTMLDivElement> & object & CSS...'.
+  Type '{ display: \\"blocks\\"; }' is not assignable to type 'Readonly<HTMLProps<HTMLDivElement> & object & CSSProperties & ExtraGlamorousProps>'.
+    Types of property 'display' are incompatible.
+      Type '\\"blocks\\"' is not assignable to type '\\"none\\" | \\"table\\" | \\"ruby\\" | \\"initial\\" | \\"inherit\\" | \\"unset\\" | \\"block\\" | \\"inline\\" | \\"run-in\\" | \\"fl...'.
+test/should-fail.test.tsx(294,32): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<HTMLProps<HTMLDivElement> & object & Ext...'.
+test/should-fail.test.tsx(295,36): error TS2559: Type '{ display: \\"block\\"; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<Component<HTMLProps<HTMLDivElement> & object & Ext...'.
 "
 `;

--- a/typings/dom-tag-component-factory.d.ts
+++ b/typings/dom-tag-component-factory.d.ts
@@ -1,0 +1,320 @@
+import {
+    KeyGlamorousComponentFactory,
+    GlamorousOptions,
+    CSSProperties,
+    SVGProperties,
+    PropsAreCssOverridesGlamorousOptions,
+    KeyGlamorousComponentFactoryCssOverides,
+} from './glamorous'
+
+export interface DOMTagGlamorousComponentFactory<Key extends keyof HTMLDomTags>  {
+    <ExternalProps, Context = object, DefaultProps extends object = object>(
+        component: Key,
+        options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
+    ): KeyGlamorousComponentFactory<
+        React.HTMLProps<HTMLDomTags[Key]>, CSSProperties, ExternalProps, DefaultProps
+    >
+
+    <ExternalProps, Context = object, DefaultProps extends object = object>(
+        component: Key,
+        options?: PropsAreCssOverridesGlamorousOptions<ExternalProps, Context, DefaultProps>,
+    ): KeyGlamorousComponentFactoryCssOverides<
+        React.HTMLProps<HTMLDomTags[Key]>, CSSProperties, ExternalProps, DefaultProps
+    >
+}
+
+export interface SVGTagGlamorousComponentFactory<Key extends keyof SVGDomTags>  {
+    <ExternalProps, Context = object, DefaultProps extends object = object>(
+        component: Key,
+        options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
+    ): KeyGlamorousComponentFactory<
+        React.SVGAttributes<SVGDomTags[Key]>, SVGProperties, ExternalProps, DefaultProps
+    >
+
+    <ExternalProps, Context = object, DefaultProps extends object = object>(
+        component: Key,
+        options?: PropsAreCssOverridesGlamorousOptions<ExternalProps, Context, DefaultProps>,
+    ): KeyGlamorousComponentFactoryCssOverides<
+        React.SVGAttributes<SVGDomTags[Key]>, SVGProperties, ExternalProps, DefaultProps
+    >
+}
+
+export interface DOMTagComponentFactory extends
+    DOMTagGlamorousComponentFactory<'a'>,
+    DOMTagGlamorousComponentFactory<'a'>,
+    DOMTagGlamorousComponentFactory<'abbr'>,
+    DOMTagGlamorousComponentFactory<'address'>,
+    DOMTagGlamorousComponentFactory<'area'>,
+    DOMTagGlamorousComponentFactory<'article'>,
+    DOMTagGlamorousComponentFactory<'aside'>,
+    DOMTagGlamorousComponentFactory<'audio'>,
+    DOMTagGlamorousComponentFactory<'b'>,
+    DOMTagGlamorousComponentFactory<'base'>,
+    DOMTagGlamorousComponentFactory<'bdi'>,
+    DOMTagGlamorousComponentFactory<'bdo'>,
+    DOMTagGlamorousComponentFactory<'big'>,
+    DOMTagGlamorousComponentFactory<'blockquote'>,
+    DOMTagGlamorousComponentFactory<'body'>,
+    DOMTagGlamorousComponentFactory<'br'>,
+    DOMTagGlamorousComponentFactory<'button'>,
+    DOMTagGlamorousComponentFactory<'canvas'>,
+    DOMTagGlamorousComponentFactory<'caption'>,
+    DOMTagGlamorousComponentFactory<'cite'>,
+    DOMTagGlamorousComponentFactory<'code'>,
+    DOMTagGlamorousComponentFactory<'col'>,
+    DOMTagGlamorousComponentFactory<'colgroup'>,
+    DOMTagGlamorousComponentFactory<'data'>,
+    DOMTagGlamorousComponentFactory<'datalist'>,
+    DOMTagGlamorousComponentFactory<'dd'>,
+    DOMTagGlamorousComponentFactory<'del'>,
+    DOMTagGlamorousComponentFactory<'details'>,
+    DOMTagGlamorousComponentFactory<'dfn'>,
+    DOMTagGlamorousComponentFactory<'dialog'>,
+    DOMTagGlamorousComponentFactory<'div'>,
+    DOMTagGlamorousComponentFactory<'dl'>,
+    DOMTagGlamorousComponentFactory<'dt'>,
+    DOMTagGlamorousComponentFactory<'em'>,
+    DOMTagGlamorousComponentFactory<'embed'>,
+    DOMTagGlamorousComponentFactory<'fieldset'>,
+    DOMTagGlamorousComponentFactory<'figcaption'>,
+    DOMTagGlamorousComponentFactory<'figure'>,
+    DOMTagGlamorousComponentFactory<'footer'>,
+    DOMTagGlamorousComponentFactory<'form'>,
+    DOMTagGlamorousComponentFactory<'h1'>,
+    DOMTagGlamorousComponentFactory<'h2'>,
+    DOMTagGlamorousComponentFactory<'h3'>,
+    DOMTagGlamorousComponentFactory<'h4'>,
+    DOMTagGlamorousComponentFactory<'h5'>,
+    DOMTagGlamorousComponentFactory<'h6'>,
+    DOMTagGlamorousComponentFactory<'head'>,
+    DOMTagGlamorousComponentFactory<'header'>,
+    DOMTagGlamorousComponentFactory<'hgroup'>,
+    DOMTagGlamorousComponentFactory<'hr'>,
+    DOMTagGlamorousComponentFactory<'html'>,
+    DOMTagGlamorousComponentFactory<'i'>,
+    DOMTagGlamorousComponentFactory<'iframe'>,
+    DOMTagGlamorousComponentFactory<'img'>,
+    DOMTagGlamorousComponentFactory<'input'>,
+    DOMTagGlamorousComponentFactory<'ins'>,
+    DOMTagGlamorousComponentFactory<'kbd'>,
+    DOMTagGlamorousComponentFactory<'keygen'>,
+    DOMTagGlamorousComponentFactory<'label'>,
+    DOMTagGlamorousComponentFactory<'legend'>,
+    DOMTagGlamorousComponentFactory<'li'>,
+    DOMTagGlamorousComponentFactory<'link'>,
+    DOMTagGlamorousComponentFactory<'main'>,
+    DOMTagGlamorousComponentFactory<'map'>,
+    DOMTagGlamorousComponentFactory<'mark'>,
+    DOMTagGlamorousComponentFactory<'menu'>,
+    DOMTagGlamorousComponentFactory<'menuitem'>,
+    DOMTagGlamorousComponentFactory<'meta'>,
+    DOMTagGlamorousComponentFactory<'meter'>,
+    DOMTagGlamorousComponentFactory<'nav'>,
+    DOMTagGlamorousComponentFactory<'noscript'>,
+    DOMTagGlamorousComponentFactory<'object'>,
+    DOMTagGlamorousComponentFactory<'ol'>,
+    DOMTagGlamorousComponentFactory<'optgroup'>,
+    DOMTagGlamorousComponentFactory<'option'>,
+    DOMTagGlamorousComponentFactory<'output'>,
+    DOMTagGlamorousComponentFactory<'p'>,
+    DOMTagGlamorousComponentFactory<'param'>,
+    DOMTagGlamorousComponentFactory<'picture'>,
+    DOMTagGlamorousComponentFactory<'pre'>,
+    DOMTagGlamorousComponentFactory<'progress'>,
+    DOMTagGlamorousComponentFactory<'q'>,
+    DOMTagGlamorousComponentFactory<'rp'>,
+    DOMTagGlamorousComponentFactory<'rt'>,
+    DOMTagGlamorousComponentFactory<'ruby'>,
+    DOMTagGlamorousComponentFactory<'s'>,
+    DOMTagGlamorousComponentFactory<'samp'>,
+    DOMTagGlamorousComponentFactory<'script'>,
+    DOMTagGlamorousComponentFactory<'section'>,
+    DOMTagGlamorousComponentFactory<'select'>,
+    DOMTagGlamorousComponentFactory<'small'>,
+    DOMTagGlamorousComponentFactory<'source'>,
+    DOMTagGlamorousComponentFactory<'span'>,
+    DOMTagGlamorousComponentFactory<'strong'>,
+    DOMTagGlamorousComponentFactory<'style'>,
+    DOMTagGlamorousComponentFactory<'sub'>,
+    DOMTagGlamorousComponentFactory<'summary'>,
+    DOMTagGlamorousComponentFactory<'sup'>,
+    DOMTagGlamorousComponentFactory<'table'>,
+    DOMTagGlamorousComponentFactory<'tbody'>,
+    DOMTagGlamorousComponentFactory<'td'>,
+    DOMTagGlamorousComponentFactory<'textarea'>,
+    DOMTagGlamorousComponentFactory<'tfoot'>,
+    DOMTagGlamorousComponentFactory<'th'>,
+    DOMTagGlamorousComponentFactory<'thead'>,
+    DOMTagGlamorousComponentFactory<'time'>,
+    DOMTagGlamorousComponentFactory<'title'>,
+    DOMTagGlamorousComponentFactory<'tr'>,
+    DOMTagGlamorousComponentFactory<'track'>,
+    DOMTagGlamorousComponentFactory<'u'>,
+    DOMTagGlamorousComponentFactory<'ul'>,
+    DOMTagGlamorousComponentFactory<'var'>,
+    DOMTagGlamorousComponentFactory<'video'>,
+    DOMTagGlamorousComponentFactory<'wbr'>
+        {}
+
+export interface SVGTagComponentFactory extends
+    SVGTagGlamorousComponentFactory<'circle'>,
+    SVGTagGlamorousComponentFactory<'clipPath'>,
+    SVGTagGlamorousComponentFactory<'defs'>,
+    SVGTagGlamorousComponentFactory<'ellipse'>,
+    SVGTagGlamorousComponentFactory<'g'>,
+    SVGTagGlamorousComponentFactory<'image'>,
+    SVGTagGlamorousComponentFactory<'line'>,
+    SVGTagGlamorousComponentFactory<'linearGradient'>,
+    SVGTagGlamorousComponentFactory<'mask'>,
+    SVGTagGlamorousComponentFactory<'path'>,
+    SVGTagGlamorousComponentFactory<'pattern'>,
+    SVGTagGlamorousComponentFactory<'polygon'>,
+    SVGTagGlamorousComponentFactory<'polyline'>,
+    SVGTagGlamorousComponentFactory<'radialGradient'>,
+    SVGTagGlamorousComponentFactory<'rect'>,
+    SVGTagGlamorousComponentFactory<'stop'>,
+    SVGTagGlamorousComponentFactory<'svg'>,
+    SVGTagGlamorousComponentFactory<'text'>,
+    SVGTagGlamorousComponentFactory<'tspan'>
+        {}
+
+
+
+export interface HTMLDomTags {
+    a: HTMLAnchorElement
+    abbr: HTMLElement
+    address: HTMLElement
+    area: HTMLAreaElement
+    article: HTMLElement
+    aside: HTMLElement
+    audio: HTMLAudioElement
+    b: HTMLElement
+    base: HTMLBaseElement
+    bdi: HTMLElement
+    bdo: HTMLElement
+    big: HTMLElement
+    blockquote: HTMLElement
+    body: HTMLBodyElement
+    br: HTMLBRElement
+    button: HTMLButtonElement
+    canvas: HTMLCanvasElement
+    caption: HTMLElement
+    cite: HTMLElement
+    code: HTMLElement
+    col: HTMLTableColElement
+    colgroup: HTMLTableColElement
+    data: HTMLElement
+    datalist: HTMLDataListElement
+    dd: HTMLElement
+    del: HTMLElement
+    details: HTMLElement
+    dfn: HTMLElement
+    dialog: HTMLElement
+    div: HTMLDivElement
+    dl: HTMLDListElement
+    dt: HTMLElement
+    em: HTMLElement
+    embed: HTMLEmbedElement
+    fieldset: HTMLFieldSetElement
+    figcaption: HTMLElement
+    figure: HTMLElement
+    footer: HTMLElement
+    form: HTMLFormElement
+    h1: HTMLHeadingElement
+    h2: HTMLHeadingElement
+    h3: HTMLHeadingElement
+    h4: HTMLHeadingElement
+    h5: HTMLHeadingElement
+    h6: HTMLHeadingElement
+    head: HTMLHeadElement
+    header: HTMLElement
+    hgroup: HTMLElement
+    hr: HTMLHRElement
+    html: HTMLHtmlElement
+    i: HTMLElement
+    iframe: HTMLIFrameElement
+    img: HTMLImageElement
+    input: HTMLInputElement
+    ins: HTMLModElement
+    kbd: HTMLElement
+    keygen: HTMLElement
+    label: HTMLLabelElement
+    legend: HTMLLegendElement
+    li: HTMLLIElement
+    link: HTMLLinkElement
+    main: HTMLElement
+    map: HTMLMapElement
+    mark: HTMLElement
+    menu: HTMLElement
+    menuitem: HTMLElement
+    meta: HTMLMetaElement
+    meter: HTMLElement
+    nav: HTMLElement
+    noscript: HTMLElement
+    object: HTMLObjectElement
+    ol: HTMLOListElement
+    optgroup: HTMLOptGroupElement
+    option: HTMLOptionElement
+    output: HTMLElement
+    p: HTMLParagraphElement
+    param: HTMLParamElement
+    picture: HTMLElement
+    pre: HTMLPreElement
+    progress: HTMLProgressElement
+    q: HTMLQuoteElement
+    rp: HTMLElement
+    rt: HTMLElement
+    ruby: HTMLElement
+    s: HTMLElement
+    samp: HTMLElement
+    script: HTMLElement
+    section: HTMLElement
+    select: HTMLSelectElement
+    small: HTMLElement
+    source: HTMLSourceElement
+    span: HTMLSpanElement
+    strong: HTMLElement
+    style: HTMLStyleElement
+    sub: HTMLElement
+    summary: HTMLElement
+    sup: HTMLElement
+    table: HTMLTableElement
+    tbody: HTMLTableSectionElement
+    td: HTMLTableDataCellElement
+    textarea: HTMLTextAreaElement
+    tfoot: HTMLTableSectionElement
+    th: HTMLTableHeaderCellElement
+    thead: HTMLTableSectionElement
+    time: HTMLElement
+    title: HTMLTitleElement
+    tr: HTMLTableRowElement
+    track: HTMLTrackElement
+    u: HTMLElement
+    ul: HTMLUListElement
+    var: HTMLElement
+    video: HTMLVideoElement
+    wbr: HTMLElement
+}
+
+export interface SVGDomTags {
+    circle: SVGCircleElement
+    clipPath: SVGClipPathElement
+    defs: SVGDefsElement
+    ellipse: SVGEllipseElement
+    g: SVGGElement
+    image: SVGImageElement
+    line: SVGLineElement
+    linearGradient: SVGLinearGradientElement
+    mask: SVGMaskElement
+    path: SVGPathElement
+    pattern: SVGPatternElement
+    polygon: SVGPolygonElement
+    polyline: SVGPolylineElement
+    radialGradient: SVGRadialGradientElement
+    rect: SVGRectElement
+    stop: SVGStopElement
+    svg: SVGSVGElement
+    text: SVGTextElement
+    tspan: SVGTSpanElement
+}
+        

--- a/typings/glamorous.d.ts
+++ b/typings/glamorous.d.ts
@@ -45,6 +45,15 @@ import {
   StyleArray,
   StyleArgument,
 } from './style-arguments'
+import {
+  DOMTagComponentFactory,
+  SVGTagComponentFactory,
+  HTMLDomTags,
+  SVGDomTags,
+  DOMTagGlamorousComponentFactory,
+  SVGTagGlamorousComponentFactory,
+} from './dom-tag-component-factory'
+
 
 import { Omit } from './helpers'
 
@@ -77,6 +86,13 @@ export {
   HTMLKey,
   SVGComponentFactory,
   SVGKey,
+
+  DOMTagComponentFactory,
+  SVGTagComponentFactory,
+  HTMLDomTags,
+  SVGDomTags,
+  DOMTagGlamorousComponentFactory,
+  SVGTagGlamorousComponentFactory,
 }
 
 export interface GlamorousOptions<Props, Context, DefaultProps> {
@@ -108,14 +124,20 @@ type OmitInternals<
 
 type GlamorousProps = { className?: string, theme?: object }
 
-export interface GlamorousInterface extends HTMLComponentFactory, SVGComponentFactory, HTMLComponent, SVGComponent {
+export interface GlamorousInterface extends
+  HTMLComponentFactory,
+  SVGComponentFactory,
+  HTMLComponent,
+  SVGComponent,
+  DOMTagComponentFactory,
+  SVGTagComponentFactory {
   // # Glamarous Component factories
   
   // Two overloads are needed per shape due to a union return of CSSProperties | SVGProperties
   // resulting in a loss of typesafety on function arguments
 
   // ## create a component factory from your own component
-  
+
   <ExternalProps, Context = object, DefaultProps extends object = object>(
     component: Component<ExternalProps & GlamorousProps>,
     options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
@@ -133,34 +155,6 @@ export interface GlamorousInterface extends HTMLComponentFactory, SVGComponentFa
     component: Component<ExternalProps & GlamorousProps>,
     options?: PropsAreCssOverridesGlamorousOptions<ExternalProps, Context, DefaultProps>,
   ): GlamorousComponentFactoryCssOverides<ExternalProps, SVGProperties, DefaultProps>
-
-  // ## create a component factory from a dom tag
-
-  <ExternalProps, Context = object, DefaultProps extends object = object>(
-    component: HTMLKey,
-    options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
-  ): KeyGlamorousComponentFactory<
-    HTMLComponentFactory[HTMLKey], CSSProperties, ExternalProps, DefaultProps
-  >
-  <ExternalProps, Context = object, DefaultProps extends object = object>(
-    component: SVGKey,
-    options?: Partial<GlamorousOptions<ExternalProps, Context, DefaultProps>>,
-  ): KeyGlamorousComponentFactory<
-    SVGComponentFactory[SVGKey], SVGProperties, ExternalProps, DefaultProps
-  >
-
-  <ExternalProps, Context = object, DefaultProps extends object = object>(
-    component: HTMLKey,
-    options?: PropsAreCssOverridesGlamorousOptions<ExternalProps, Context, DefaultProps>,
-  ): KeyGlamorousComponentFactoryCssOverides<
-    HTMLComponentFactory[HTMLKey], CSSProperties, ExternalProps, DefaultProps
-  >
-  <ExternalProps, Context = object, DefaultProps extends object = object>(
-    component: SVGKey,
-    options?: PropsAreCssOverridesGlamorousOptions<ExternalProps, Context, DefaultProps>,
-  ): KeyGlamorousComponentFactoryCssOverides<
-    SVGComponentFactory[SVGKey], SVGProperties, ExternalProps, DefaultProps
-  >
 }
 
 interface ThemeProps {


### PR DESCRIPTION
**What**:

Fixes dom-tag component factories and also cleans up parameter hints for components created in this style.

**Why**:

When glamorous component factories are created from strings currently they incorrectly union all Dom Element interfaces. 

**How**:

Extended the Glamorous interface with two new interfaces (`DOMTagComponentFactory` + `SVGTagComponentFactory`) which add overloads to the glamorous interface for component factories created with all dom-tag keys.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests
- [ ] Ready to be merged
- [x] Added myself to contributors table

Parameter hinting with correct dom-tag component factory typing:
<img width="400" alt="screen shot 2017-08-27 at 3 08 57 pm" src="https://user-images.githubusercontent.com/848525/29748452-ce909174-8b49-11e7-82e3-b7b0ddb6ca15.png">

Parameter hinting with current incorrect dom-tag component factory typing:
<img width="400" alt="screen shot 2017-08-27 at 3 12 49 pm" src="https://user-images.githubusercontent.com/848525/29748440-994cbdd0-8b49-11e7-99a4-137357b492b2.png">


I'm likely to open a couple of additional PRs this afternoon based off this one which continue the effort started in https://github.com/paypal/glamorous/pull/301 to improve parameter hints. 
