### PR TITLE
fix(typings): cast `theme` prop as any rather than object

### DIFF
--- a/typings/component-factory.d.ts
+++ b/typings/component-factory.d.ts
@@ -13,7 +13,7 @@ export interface BuiltInGlamorousComponentFactory<ElementProps, Properties> {
     object
   >;
 
-  <Props extends { theme: object }>(
+  <Props extends { theme: any }>(
     ...styles: StyleArgument<Properties, Props>[]
   ): GlamorousComponent<
     Omit<Props, 'theme'> & ElementProps,

--- a/typings/glamorous-component.d.ts
+++ b/typings/glamorous-component.d.ts
@@ -21,7 +21,7 @@ export interface ExtraGlamorousProps {
    * Same type as any of the styles provided, will be merged with this component's styles and take highest priority over the component's predefined styles
    */
   css?: CSSProperties;
-  theme?: object;
+  theme?: any;
 }
 
 export interface GlamorousComponentFunctions<ExternalProps, Props> {


### PR DESCRIPTION
This PR introduces a fix to an issue that manifests itself when trying to use TypeScript and glamorous together, specifically in conjunction with the `theme` prop.

To illustrate, consider the following piece(s) of code:


```typescript
interface StyleBase {
  base: string;
  text: string;
}

export interface Theme {
  dark: StyleBase;
  light: StyleBase;
  primary: 'dark' | 'light';
}

export const THEME = {
  dark: {
    base: '#1E1E20',
    text: '#ddd'
  },
  light: {
    base: '#ECF0F1',
    text: '#1E1E20'
  },
  primary: 'dark'
};
```


```typescript
const Container = glamorous.div(
  {
    display: 'flex',
    width: '100%',
    maxWidth: '100%',
    height: '100%',
    overflow: 'auto',
    position: 'relative',
    WebkitOverflowScrolling: 'touch',
    zIndex: 2,
    boxSizing: 'border-box',
    borderStyle: 'solid',
    borderWidth: 0,
    borderBottomWidth: 1,
    [`@media only screen and (min-width: 768px)`]: {
      borderBottomWidth: 0,
      borderRightWidth: 1,
      height: 'auto'
    }
  },
  ({ theme }) => ({
    borderColor: darken(0.15, theme[theme.primary].base)
  })
);
```

Without this fix, TypeScript will error and throw messages of the form

```
ERROR in [at-loader] ./src/components/CodeEditor/index.tsx:36:43 
    TS2339: Property 'primary' does not exist on type 'object'.
```

With this fix, no errors are thrown to the console or by TypeScript.