### PR TITLE
Fix package.json `module` to use ".esm.js" extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0-semantically-released",
   "description": "React component styling solved",
   "main": "dist/glamorous.cjs.js",
-  "jsnext:main": "dist/glamorous.es.js",
-  "module": "dist/glamorous.es.js",
+  "jsnext:main": "dist/glamorous.esm.js",
+  "module": "dist/glamorous.esm.js",
   "typings": "typings/glamorous.d.ts",
   "scripts": {
     "add-contributor": "kcd-scripts contributors add",


### PR DESCRIPTION
Fix the `"module"` and `"jsnext:main"` package.json entries to reference the actual built `dist/glamorous.esm.js` file. See [glamorous build 4.9](https://unpkg.com/glamorous@4.9.0/dist/).

This allows glamorous to build with Rollup.js's support for ES6 "module" entries.