### PR TITLE
fix(propTypes): allow object as className

### DIFF
--- a/src/__tests__/create-glamorous.with-component.js
+++ b/src/__tests__/create-glamorous.with-component.js
@@ -60,6 +60,6 @@ test('resulting component can have its styles extended further', () => {
     'overriding styles via css prop',
   )
   expect(
-    render(<View className={glamor.css({color: 'green'}).toString()} />),
+    render(<View className={glamor.css({color: 'green'})} />),
   ).toMatchSnapshot('overriding styles via className')
 })

--- a/src/create-glamorous.js
+++ b/src/create-glamorous.js
@@ -95,7 +95,9 @@ function createGlamorous(splitProps) {
       )
 
       GlamorousComponent.propTypes = {
-        className: PropTypes.string,
+        // className accepts an object due to glamor's css function
+        // returning an object with a toString method that gives the className
+        className: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
         cssOverrides: PropTypes.object,
         innerRef: PropTypes.func,
         glam: PropTypes.object,


### PR DESCRIPTION
**What**: This adds `object` as an option for `className` to allow for passing `glamor.css` to the `className` prop.

<!-- Why are these changes necessary? -->
**Why**: This closes #332

<!-- How were these changes implemented? -->
**How**: `PropTypes.oneOfType`

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

cc @Tibfib and @marzelin 