### PR TITLE
fix(typescript): remove deprecated npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:update": "npm run test:cover -s -- --updateSnapshot",
     "test:build": "kcd-scripts test --config other/jest.config.js --no-watch",
     "build-and-test": "npm run build -s && npm run test:build -s",
-    "validate": "kcd-scripts validate lint,build-and-test,test:cover,test:ts",
+    "validate": "kcd-scripts validate lint,build-and-test,test:cover",
     "precommit": "kcd-scripts precommit"
   },
   "files": ["dist", "typings", "preact"],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "test:update": "npm run test:cover -s -- --updateSnapshot",
     "test:build": "kcd-scripts test --config other/jest.config.js --no-watch",
     "build-and-test": "npm run build -s && npm run test:build -s",
-    "test:ts": "(tsc -p ./tsconfig.json && rimraf test-ts) || rimraf test-ts",
     "validate": "kcd-scripts validate lint,build-and-test,test:cover,test:ts",
     "precommit": "kcd-scripts precommit"
   },


### PR DESCRIPTION
The `test:ts` script was being used previously to test that the
typescript definitions were working correctly.  These were moved
into the main tests to allow snapshots to be maintained with
extra tests which ensure the defintions fail on incorrect usage
of glamorous.


**What/How**:

remove deprecated npm script `test:ts`

**Why**:

It now fails with the should-fail test file.

**Checklist**:
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged

closes #335 
