### PR TITLE
Delay instantation of brcast in ThemeProvider so it can be inited wit…

### DIFF
--- a/src/theme-provider.js
+++ b/src/theme-provider.js
@@ -14,8 +14,6 @@ import {CHANNEL} from './constants'
  * @param {Object} theme the theme object..
  */
 class ThemeProvider extends React.Component {
-  broadcast = brcast(this.props.theme)
-
   // create theme, by merging with outer theme, if present
   getTheme(passedTheme) {
     const theme = passedTheme || this.props.theme
@@ -40,7 +38,9 @@ class ThemeProvider extends React.Component {
 
   setOuterTheme = theme => {
     this.outerTheme = theme
-    this.publishTheme()
+    if (this.broadcast !== undefined) {
+      this.publishTheme()
+    }
   }
 
   publishTheme(theme) {
@@ -59,6 +59,7 @@ class ThemeProvider extends React.Component {
     if (this.context[CHANNEL]) {
       this.setOuterTheme(this.context[CHANNEL].getState())
     }
+    this.broadcast = brcast(this.getTheme(this.props.theme))
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
…h correct initialState

**What**:
Delayed initialization of brcast to `componentWillMount`

**Why**:
So it won't ever get "untrue" initialState in case of nested ThemeProviders

**Checklist**:
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

This is a follow up PR to the discussion [here](https://github.com/paypal/glamorous/pull/363#discussion_r158365405)
