### PR TITLE
fix(Contributing): remove outdated hook opt-in

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,18 +49,6 @@ Please make sure to run the tests before you commit your changes. You can run
 `npm run test:update` which will update any snapshots that need updating.
 Make sure to include those changes (if they exist) in your commit.
 
-### opt into git hooks
-
-There are git hooks set up with this project that are automatically installed
-when you install dependencies. They're really handy, but are turned off by
-default (so as to not hinder new contributors). You can opt into these by
-creating a file called `.opt-in` at the root of the project and putting this
-inside:
-
-```
-pre-commit
-```
-
 ## Help needed
 
 Please checkout the [the open issues][issues]


### PR DESCRIPTION
**What**: fixed documentation.

**Why**: because it was misleading.

**How**: by editing the text.

**Checklist**:

* [x] Documentation
* [ ] Tests N/A
* [x] Ready to be merged
* [ ] Added myself to contributors table

  On a fresh clone and `npm install`, the hook was enabled already by `husky`, which [does not have opt-in](https://github.com/typicode/husky/issues/59).

Fixup 2a57031bcf.
