### PR TITLE
TypeScript: Add recursive array type to CSS prop

### DIFF
--- a/typings/css-properties.d.ts
+++ b/typings/css-properties.d.ts
@@ -1932,3 +1932,7 @@ export interface CSSProperties
   extends CSSPropertiesComplete,
     CSSPropertiesPseudo,
     CSSPropertiesLossy {}
+
+export type CSSPropertiesRecursive = CSSProperties | CSSPropertiesArray
+
+export interface CSSPropertiesArray extends Array<CSSPropertiesRecursive> {}

--- a/typings/glamorous-component.d.ts
+++ b/typings/glamorous-component.d.ts
@@ -1,4 +1,4 @@
-import {CSSProperties} from './css-properties'
+import {CSSProperties, CSSPropertiesRecursive} from './css-properties'
 
 import {Component} from './glamorous'
 
@@ -20,7 +20,7 @@ export interface ExtraGlamorousProps {
   /**
    * Same type as any of the styles provided, will be merged with this component's styles and take highest priority over the component's predefined styles
    */
-  css?: CSSProperties
+  css?: CSSPropertiesRecursive
   theme?: object
 }
 

--- a/typings/glamorous-component.d.ts
+++ b/typings/glamorous-component.d.ts
@@ -1,4 +1,4 @@
-import {CSSProperties, CSSPropertiesRecursive} from './css-properties'
+import {CSSPropertiesRecursive} from './css-properties'
 
 import {Component} from './glamorous'
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes the type definitions for `css` prop. The `css` prop actually accepts either an object or an array of nested objects/arrays.

<!-- Why are these changes necessary? -->

**Why**:
TypeScript support

<!-- How were these changes implemented? -->

**How**:
Leverage recursive types described in this comment: https://github.com/Microsoft/TypeScript/issues/3496#issuecomment-128553540

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

The build fails due to previous failure. I have PR #382 that fixes this.